### PR TITLE
Multiple Property values

### DIFF
--- a/ui/src/components/directory/viewer/dataModel/DataModel.vue
+++ b/ui/src/components/directory/viewer/dataModel/DataModel.vue
@@ -211,7 +211,15 @@ async function createOrNode(ttproperty: any, cardinality: string, index: any, pr
 function createNode(ttproperty: any, entity2: any[], index: any, cardinality: string, propertyList: TreeNode[], parentKey: string) {
   const type = ttproperty[SHACL.CLASS] || ttproperty[SHACL.NODE] || ttproperty[SHACL.DATATYPE] || ttproperty[SHACL.NAMESPACE + "dataType"] || [];
   const group = ttproperty?.[SHACL.GROUP]?.[0];
-  const name = `${ttproperty[SHACL.PATH]?.[0].name}  ${isArrayHasLength(type) ? "(" + (type[0].name ? type[0].name : type[0]["@id"]) + ")" : ""}`;
+  let name = ttproperty[SHACL.PATH]?.[0].name;
+  if (isArrayHasLength(type)){
+    if (type.length==1){
+      name=name+"("+ (type[0].name ? type[0].name : type[0]["@id"]) + ")";
+    }
+    else
+      name=name+"(any of the below)";
+  }
+
   const typeTypes = isObjectHasKeys(entity2[index], [RDF.TYPE]) ? entity2[index][RDF.TYPE] : [];
   const property = {
     key: parentKey + "-" + index.toString(),
@@ -220,7 +228,7 @@ function createNode(ttproperty: any, entity2: any[], index: any, cardinality: st
     selectable: true,
     loading: false,
     data: {
-      type: [isArrayHasLength(type) ? type[0] : ""],
+      type : isArrayHasLength(type) ? [...type] : [],
       cardinality: cardinality,
       isOr: false,
       typeIcon: getFAIconFromType(typeTypes),


### PR DESCRIPTION
Concept role groups and data model properties may point to an array of values. Current viewers display only the first so detailsbuilder and dataModel.vue modified to support an array of values
![image](https://github.com/user-attachments/assets/1d7544a9-5e91-4824-9363-ace7ac82d0db)
