### PR TITLE
Further tweeks to query display

### DIFF
--- a/im_library/src/interfaces/AutoGen.ts
+++ b/im_library/src/interfaces/AutoGen.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-// Generated using typescript-generator version 3.2.1263 on 2024-10-17 14:23:43.
+// Generated using typescript-generator version 3.2.1263 on 2024-10-30 09:24:55.
 
 export interface DataModelProperty extends Serializable {
     property?: TTIriRef;
@@ -251,17 +251,14 @@ export interface Argument {
     valueIriList?: TTIriRef[];
     valueDataList?: string[];
     valueObject?: any;
-    valueWherePath?: IriLD[];
-    whereUnits?: boolean;
-    valueMatchPath?: IriLD[];
 }
 
 export interface Assignable {
     value?: string;
-    qualifier?: string;
     unit?: string;
-    valueLabel?: string;
     operator?: Operator;
+    valueLabel?: string;
+    qualifier?: string;
 }
 
 export interface Case {
@@ -295,8 +292,8 @@ export interface Element extends IriLD, Entailment {
 
 export interface Entailment {
     descendantsOf?: boolean;
-    ancestorsOf?: boolean;
     memberOf?: boolean;
+    ancestorsOf?: boolean;
     descendantsOrSelfOf?: boolean;
 }
 
@@ -333,9 +330,11 @@ export interface Match extends IriLD {
     path?: IriLD[];
     displayLabel?: string;
     hasInlineSet?: boolean;
+    function?: FunctionClause;
 }
 
 export interface Node extends Element {
+    type?: string;
     exclude?: boolean;
     code?: string;
 }
@@ -429,8 +428,8 @@ export interface ReturnProperty {
     description?: string;
     match?: Match[];
     boolMatch?: Bool;
-    return?: Return;
     case?: Case;
+    return?: Return;
 }
 
 export interface Update extends TTIriRef {
@@ -788,10 +787,10 @@ export interface TTEntity extends TTNode, Serializable {
     type?: TTArray;
     scheme?: TTIriRef;
     version?: number;
-    status?: TTIriRef;
     description?: string;
-    prefixes?: TTPrefix[];
+    status?: TTIriRef;
     code?: string;
+    prefixes?: TTPrefix[];
 }
 
 export interface TTContext extends Serializable {

--- a/ui/src/components/query/viewer/MatchSummaryDisplay.vue
+++ b/ui/src/components/query/viewer/MatchSummaryDisplay.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="pl-8" id="match-summary-display">
-    <span v-if="match.name">
+
+    <div  id="match-summary-display" v-if="match.name">
       <Button text :icon="!matchExpanded ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-up'" @click="toggle" />
       <span v-if="index > 0" :class="operator">{{ operator }}</span>
       <span>{{ match.name }}</span>
@@ -8,12 +8,11 @@
         <span class="pl-8 text-gray-500">details:</span>
         <RecursiveMatchDisplay :inline="false" :match="match" :depth="1" :index="index" :operator="operator" :expanded="true" />
       </div>
-    </span>
+    </div>
 
     <span v-else>
-      <RecursiveMatchDisplay :inline="false" :match="match" :depth="1" :index="index" :operator="operator" :expanded="true" />
+      <RecursiveMatchDisplay :inline="false" :match="match" :depth="0" :index="index" :operator="operator" :expanded="true" />
     </span>
-  </div>
 </template>
 
 <script setup lang="ts">
@@ -44,14 +43,7 @@ watch(
 </script>
 
 <style scoped>
-.return {
-  color: var(--p-teal-500);
-  padding-left: 0.5rem;
-}
 
-.output {
-  color: var(--p-indigo-500);
-}
 
 #match-summary-display:deep(.or) {
   color: var(--p-blue-500);

--- a/ui/src/components/query/viewer/RecursiveMatchDisplay.vue
+++ b/ui/src/components/query/viewer/RecursiveMatchDisplay.vue
@@ -24,7 +24,7 @@
       />
     </div>
 
-    <div v-if="isArrayHasLength(match.where)">
+    <span v-if="isArrayHasLength(match.where)">
       <RecursiveWhereDisplay
         v-for="(nestedWhere, index) in match.where"
         :where="nestedWhere"
@@ -33,9 +33,9 @@
         :key="index"
         :index="index"
         :operator="match.boolWhere"
-        :expanded="expandSet"
+        :expandedSet="expandSet"
       />
-    </div>
+    </span>
 
     <RecursiveMatchDisplay v-if="match.then" :match="match.then" :inline="false" :index="0" :depth="1" />
 
@@ -63,7 +63,8 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const expandSet = ref(false);
+const expandSet: Ref<boolean> = ref(false);
+
 
 function toggle() {
   expandSet.value = !expandSet.value;

--- a/ui/src/components/query/viewer/RecursiveQueryDisplay.vue
+++ b/ui/src/components/query/viewer/RecursiveQueryDisplay.vue
@@ -27,7 +27,7 @@
           :index="index"
           :key="index"
           :operator="query.boolWhere"
-          :expanded="false"
+          :expandedSet="false"
         />
       </span>
       <span v-if="matchExpand && isArrayHasLength(query.return)">

--- a/ui/src/components/query/viewer/RecursiveWhereDisplay.vue
+++ b/ui/src/components/query/viewer/RecursiveWhereDisplay.vue
@@ -12,16 +12,26 @@
       </span>
       <span class="node-ref">{{ where.relativeTo.nodeRef }}</span>
     </span>
-    <ul v-if="expanded">
-      <li v-for="(item, index) in where.is" :key="index">
-        <span style="padding-left: 3rem"></span>
-        <span v-if="item.descendantsOrSelfOf"><<</span>
-        <span class="field"> {{ item.name }}</span>
-        <span v-if="item.code">({{ item.code }})</span>
-      </li>
-    </ul>
   </span>
   <span v-if="where.nodeRef" class="node-ref">{{ where.nodeRef }}</span>
+ <span v-if="expandedSet&&isArrayHasLength(where.is)">
+   <span>, defined as</span>
+   <div>
+    <span style="list-style-type: none; padding-left: 0;">
+      <span v-for="(item, index) in where.is" :key="index" style="padding-left: 1.5rem;">
+        <ul>
+          <li class="tight-spacing">
+            <span v-if="item.qualifier" v-html="item.qualifier"></span>
+            <span class="field"> {{ item.name }}</span>
+            <span v-if="item.code">({{ item.code }})</span>
+             <span v-if="item.descendantsOrSelfOf">+subtypes</span>
+          </li>
+        </ul>
+      </span>
+ </span>
+  </div>
+
+ </span>
 
   <div v-if="isArrayHasLength(where.where)" :style="indentationStyle(depth + 1)">
     <span :class="where.operator"> {{ operator }}</span>
@@ -35,27 +45,31 @@
         :operator="where.boolWhere"
         :key="index"
         :depth="depth + 1"
-        :expanded="expanded"
+        :expandedSet="expandedSet"
       />
       <span>)</span>
     </div>
   </div>
 
   <RecursiveMatchDisplay v-if="where.match" :match="where.match" :depth="depth + 1" :inline="true" :index="0" :expanded="childExpand" />
+
+
+
+
 </template>
 
 <script setup lang="ts">
 import { isArrayHasLength } from "@im-library/helpers/DataTypeCheckers";
 import { Where, Assignable, Bool } from "@im-library/interfaces/AutoGen";
-import { Ref, ref, watch } from "vue";
 import RecursiveMatchDisplay from "./RecursiveMatchDisplay.vue";
+import {IM} from "@im-library/vocabulary/IM"
 
 interface Props {
   where: Where;
   index: number;
   depth: number;
-  expanded: boolean;
   operator?: Bool;
+  expandedSet: boolean;
 }
 
 const props = defineProps<Props>();
@@ -81,6 +95,12 @@ function indentationStyle(depth: number) {
 </script>
 
 <style scoped>
+.tight-spacing {
+  margin-top: -1rem;
+  margin-bottom: 0.5rem;
+  padding-left: 3rem;
+}
+
 .field {
   padding-right: 0.2rem;
 }


### PR DESCRIPTION
No preload needed but IMAPI should be up to date.
Match Summary display needed an id to make the deep clone classes work.
Remove the div for match clause summary when there is no name
Change to the where in detail display to replace the arcane << with subtypes and to properly show whether they are sets or cohort queries
Change to the where clause when expanded to keep the inline approach but insert the set display.
Goes along with IMAPI committed change to Query descritptor to populate the where is nodes with set or cohort qualifiers
before
![image](https://github.com/user-attachments/assets/969c45dd-88f6-4817-aeda-b6b43b1b9b32)
![image](https://github.com/user-attachments/assets/ccccf4c4-d6ea-4efb-8bc7-ddaa7048d2de)

after
![image](https://github.com/user-attachments/assets/5b4b2e2d-55fe-4d55-8019-7f7d73133d33)
![image](https://github.com/user-attachments/assets/429cfe18-15a6-4d35-8783-fa56234a7464)

