### PR TITLE
Set display displays entailed members

### DIFF
--- a/src/components/directory/viewer/QueryDisplay.vue
+++ b/src/components/directory/viewer/QueryDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="query-display" class="flex flex-1 flex-col">
     <div v-if="loading" class="flex flex-row"><ProgressSpinner /></div>
-    <div v-else-if="!isObjectHasKeys(query)">No definition found.</div>
+    <div v-else-if="!isObjectHasKeys(query)">No expression or query definition found.</div>
     <div v-else class="query-display-container flex flex-col gap-4">
       <div class="flex flex-row gap-2">
         <div v-if="showSqlButton"><Button label="Generate SQL" @click="generateSQL" data-testid="sql-button" /></div>

--- a/src/components/directory/viewer/dataModel/DataModel.vue
+++ b/src/components/directory/viewer/dataModel/DataModel.vue
@@ -141,13 +141,46 @@ function createGroupNode(property: PropertyShape, index: any, propertyList: Tree
   }
 }
 
-function createParameterNode(property:PropertyShape,propertyNode:TreeNode){
+
+function createQualifierNode(property:PropertyShape,rangeNode:TreeNode) {
+  if (property.datatype) {
+    if (property.datatype.qualifier) {
+      let qualifiers = "qualifiers ->";
+      qualifiers = qualifiers + property.datatype.qualifier.map(item => item.name).join(", ");
+      setQualifierNode(qualifiers, rangeNode,property.datatype["@id"],0);
+    }
+    if (property.datatype.units) {
+      setQualifierNode("units : "+ property.datatype.units.name, rangeNode,property.datatype["@id"],1);
+    }
+    if (property.datatype.operator) {
+      setQualifierNode("operators : <,>,<=,>=", rangeNode,property.datatype["@id"],2);
+    }
+  }
+}
+function setQualifierNode(qualifiers : string, rangeNode:TreeNode,iri: string,index:number){
+    const qualifierNode = {
+          key: rangeNode.key + "-q"+ index,
+          label: qualifiers,
+          children: [] as TreeNode[],
+          selectable: true,
+          loading: false,
+          data: {
+            typeIcon: getFAIconFromType([{"@id": IM.CONCEPT}]),
+            color: getColourFromType([{"@id": IM.CONCEPT}]),
+            iri :iri
+          },
+          type: "type"
+        } as TreeNode;
+        rangeNode.children!.push(qualifierNode);
+}
+
+function createParameterNode(property:PropertyShape,rangeNode:TreeNode){
   if (property.parameter &&property.parameter.length){
     let params="parameters : ";
     for (const [index,parameter] of property.parameter.entries()) {
       if (parameter.type) {
         const parameterNode = {
-          key: propertyNode.key + "-p" + index.toString(),
+          key: rangeNode.key + "-p" + index.toString(),
           label: "parameter -> "+parameter.label + ", type :" + parameter.type?.name,
           children: [] as TreeNode[],
           selectable: true,
@@ -157,9 +190,9 @@ function createParameterNode(property:PropertyShape,propertyNode:TreeNode){
             color: getColourFromType([{"@id": IM.CONCEPT}]),
             iri: parameter.type["@id"]
           },
-          type: "parameter"
+          type: "type"
         } as TreeNode;
-        propertyNode.children!.push(parameterNode);
+        rangeNode.children!.push(parameterNode);
       }
     }
   }
@@ -198,6 +231,8 @@ function createRangeNode(property: PropertyShape,propertyNode: TreeNode){
         type: "type"
       } as TreeNode;
       propertyNode.children!.push(rangeNode);
+      createParameterNode(property, rangeNode);
+      createQualifierNode(property,rangeNode);
       }
 }
 
@@ -256,7 +291,6 @@ function createPropertyNode(property: PropertyShape, index: any, propertyList: T
         } as TreeNode;
 
         createRangeNode(property, propertyNode);
-        createParameterNode(property, propertyNode);
         propertyList.push(propertyNode);
       }
 

--- a/src/components/directory/viewer/set/SetDefinition.vue
+++ b/src/components/directory/viewer/set/SetDefinition.vue
@@ -35,7 +35,7 @@
       <AccordionPanel value="1">
         <AccordionContent>
           <div class="definition-header">
-            <span>Definition</span>
+            <span>Expression based definition (ECL) </span>
             <Button
               v-tooltip.top="'Copy definition'"
               class="p-button-outlined concept-button"
@@ -51,7 +51,7 @@
         </div>
       </AccordionPanel>
       <AccordionPanel header="Direct Members" value="2">
-        <AccordionHeader>Direct Members</AccordionHeader>
+        <AccordionHeader>Direct or entailed members</AccordionHeader>
         <AccordionContent>
           <div id="members-container" class="set-accordion-content">
             <Members :entityIri="props.entityIri" @navigateTo="(iri: string) => emit('navigateTo', iri)" @open-download-dialog="displayDialog" />
@@ -124,7 +124,7 @@ const hasDefinition = computed(() => isObjectHasKeys(entity.value, [IM.DEFINITIO
 
 onMounted(async () => {
   active.value = ["0", "1", "2"];
-  entity.value = await EntityService.getPartialEntity(props.entityIri, [IM.IS_SUBSET_OF, IM.IS_CONTAINED_IN, RDFS.SUBCLASS_OF, IM.DEFINITION, IM.HAS_MEMBER]);
+  entity.value = await EntityService.getPartialEntity(props.entityIri, [IM.IS_SUBSET_OF, IM.IS_CONTAINED_IN, RDFS.SUBCLASS_OF, IM.DEFINITION]);
   if (entity.value[IM.IS_SUBSET_OF]) {
     subsetOf.value = entity.value[IM.IS_SUBSET_OF];
   }

--- a/src/helpers/ConceptTypeMethods.ts
+++ b/src/helpers/ConceptTypeMethods.ts
@@ -42,7 +42,7 @@ export function isQuery(entityTypes: TTIriRef[]): boolean {
 }
 
 export function isRecordModel(entityTypes: TTIriRef[]): boolean {
-  return isOfTypes(entityTypes, SHACL.NODESHAPE,RDFS.DATATYPE);
+  return isOfTypes(entityTypes, SHACL.NODESHAPE);
 }
 
 export function isFolder(entityTypes: TTIriRef[]): boolean {

--- a/src/interfaces/AutoGen.ts
+++ b/src/interfaces/AutoGen.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-// Generated using typescript-generator version 3.2.1263 on 2024-12-13 09:10:15.
+// Generated using typescript-generator version 3.2.1263 on 2024-12-16 10:46:32.
 
 export interface DataModelProperty extends Serializable {
     property?: TTIriRef;
@@ -198,6 +198,8 @@ export interface PropertyRange extends TTIriRef {
     intervalUnit?: TTIriRef;
     qualifier?: PropertyRange[];
     type?: TTIriRef;
+    units?: TTIriRef;
+    operator?: TTIriRef;
 }
 
 export interface PropertyShape {
@@ -275,11 +277,11 @@ export interface Argument {
 
 export interface Assignable {
     value?: string;
+    qualifier?: string;
     operator?: Operator;
     intervalUnit?: TTIriRef;
-    qualifier?: string;
-    valueParameter?: string;
     valueLabel?: string;
+    valueParameter?: string;
 }
 
 export interface Case {
@@ -314,8 +316,8 @@ export interface Element extends IriLD, Entailment {
 export interface Entailment {
     memberOf?: boolean;
     descendantsOrSelfOf?: boolean;
-    ancestorsOf?: boolean;
     descendantsOf?: boolean;
+    ancestorsOf?: boolean;
 }
 
 export interface FunctionClause extends Value {
@@ -795,8 +797,8 @@ export interface StackTraceElement extends Serializable {
     methodName?: string;
     fileName?: string;
     lineNumber?: number;
-    className?: string;
     nativeMethod?: boolean;
+    className?: string;
 }
 
 export interface Exception extends Throwable {
@@ -806,19 +808,19 @@ export interface TTEntity extends TTNode, Serializable {
     context?: TTContext;
     crud?: TTIriRef;
     graph?: TTIriRef;
-    type?: TTArray;
     name?: string;
+    type?: TTArray;
     scheme?: TTIriRef;
     version?: number;
     status?: TTIriRef;
     description?: string;
-    code?: string;
     prefixes?: TTPrefix[];
+    code?: string;
 }
 
 export interface TTContext extends Serializable {
-    nameSpaces?: TTPrefix[];
     prefixes?: TTPrefix[];
+    nameSpaces?: TTPrefix[];
 }
 
 export interface TTValue extends Serializable {

--- a/src/services/SetService.ts
+++ b/src/services/SetService.ts
@@ -18,6 +18,18 @@ const SetService = {
       raw: raw
     });
   },
+  async getMembers(
+      iri: string,
+      entailments: boolean,
+      pageIndex: number,
+      pageSize: number,
+      controller?: AbortController
+  ): Promise<any> {
+    return axios.get(API_URL + "/public/members", {
+      params: { iri: iri,  entailments: entailments,page: pageIndex, size: pageSize },
+      signal: controller?.signal
+    });
+  },
 
   async getFullyExpandedSetMembers(iri: string, legacy: boolean, includeSubsets: boolean): Promise<TTIriRef[]> {
     return axios.get(API_URL + "/public/expandedMembers", {

--- a/src/vocabulary/IM.ts
+++ b/src/vocabulary/IM.ts
@@ -6,6 +6,7 @@ export class IM {
   public static readonly NAMESPACE = IM.DOMAIN + IM.PREFIX + "#";
   public static readonly DESCENDANTS_OR_SELF_OF = IM.NAMESPACE + "DescendantsOrSelfOf";
   public static readonly DESCENDANTS_OF = IM.NAMESPACE + "DescendantsOf";
+  public static readonly FULLY_SPECIFIED_NAME = IM.NAMESPACE + "fullySpecifiedName";
   public static readonly ANCESTORS_OF = IM.NAMESPACE + "DncestorsOf";
   public static readonly ENTAILED_MEMBER = IM.NAMESPACE + "entailedMember";
   public static readonly ENTAILMENT = IM.NAMESPACE + "entailment";


### PR DESCRIPTION
Latest IMAPI (dev) required, Preload needed to expand the sets properly

Sets now have 3 modes of definition
1. Expression based (im:definition - ECL)
2. Entailed members (im:entailedMembers) list of members with entailments equivalent to a large ECL OR list
3. Direct members (im:hasMember)

SetDefinition.vue and Members.vue displays 2) if present rather than 3 as 3) can be inferred from 2) and is available on expansion
