### PR TITLE
Increase file upload size limit to 12MB.

### DIFF
--- a/src/components/uprn/AddressFileWorkflow.vue
+++ b/src/components/uprn/AddressFileWorkflow.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="address-file-workflow">
-    <FileUpload mode="advanced" :maxFileSize="4000000" customUpload @uploader="handleFileUpload" chooseLabel="Browse" accept=".txt" :multiple="true" />
+    <FileUpload mode="advanced" :maxFileSize="12000000" customUpload @uploader="handleFileUpload" chooseLabel="Browse" accept=".txt" :multiple="true" />
     <div id="address-file-instructions">
       <p>
         The address file to be uploaded must contain two columns separated by a single tab character with a .txt extension<br />


### PR DESCRIPTION
The maximum file size for uploads was changed from 4MB to 12MB in the AddressFileWorkflow component. This allows users to upload larger address files, improving usability for extensive datasets.