### PR TITLE
refactor(api): standardize api endpoint prefixes and access levels

### DIFF
--- a/src/composables/useCreateNew.ts
+++ b/src/composables/useCreateNew.ts
@@ -54,7 +54,7 @@ export function useCreateNew() {
   }
 
   async function checkExists(iri: string): Promise<boolean> {
-    if (await EntityService.checkExists(iri)) {
+    if (await EntityService.entityExists(iri)) {
       await Swal.fire({
         icon: "warning",
         title: "Warning",

--- a/src/composables/useValidity.ts
+++ b/src/composables/useValidity.ts
@@ -37,7 +37,7 @@ export function useValidity(shape?: FormGenerator) {
   }
 
   async function checkExists(iri: string): Promise<boolean> {
-    if (await EntityService.checkExists(iri)) {
+    if (await EntityService.entityExists(iri)) {
       await Swal.fire({
         icon: "warning",
         title: "Warning",

--- a/src/services/CodeGenService.ts
+++ b/src/services/CodeGenService.ts
@@ -3,24 +3,24 @@ import axios from "axios";
 import { CodeTemplate } from "@/interfaces";
 import { CodeGenDto } from "@/interfaces/AutoGen";
 
-const API_URL = Env.API + "api/codeGen";
+const API_URL = Env.API + "api/codeGen/public";
 
 const CodeGenService = {
   async getCodeTemplateList(): Promise<string[]> {
-    return await axios.get(API_URL + "/private/codeTemplates");
+    return await axios.get(API_URL + "/codeTemplates");
   },
   async getCodeTemplate(name: string): Promise<CodeGenDto> {
-    return await axios.get(API_URL + "/private/codeTemplate", {
+    return await axios.get(API_URL + "/codeTemplate", {
       params: {
         templateName: name
       }
     });
   },
   async updateCodeTemplate(template: CodeGenDto): Promise<string> {
-    return await axios.post(API_URL + "/private/codeTemplate", template);
+    return await axios.post(API_URL + "/codeTemplate", template);
   },
   async generateCodeForAllModels(namespace: string, template: string): Promise<Blob> {
-    return await axios.get(API_URL + "/private/generateCode", {
+    return await axios.get(API_URL + "/generateCode", {
       params: {
         template,
         namespace
@@ -29,7 +29,7 @@ const CodeGenService = {
     });
   },
   async generateCodeForModel(template: CodeTemplate, modelIri: string, namespace: string): Promise<string> {
-    return await axios.post(API_URL + "/private/generateCodePreview", template, {
+    return await axios.post(API_URL + "/generateCodePreview", template, {
       params: {
         iri: modelIri,
         namespace

--- a/src/services/ConceptService.ts
+++ b/src/services/ConceptService.ts
@@ -2,11 +2,11 @@ import { SimpleMap, TermCode } from "@/interfaces";
 import Env from "./Env";
 import axios from "axios";
 import { ConceptContextMap } from "@/interfaces/AutoGen";
-const API_URL = Env.API + "api/concept";
+const API_URL = Env.API + "api/concept/protected";
 
 const ConceptService = {
   async getMatchedFrom(iri: string): Promise<SimpleMap[]> {
-    return await axios.get(API_URL + "/private/matchedFrom", {
+    return await axios.get(API_URL + "/matchedFrom", {
       params: {
         iri: iri
       }
@@ -14,7 +14,7 @@ const ConceptService = {
   },
 
   async getMatchedTo(iri: string): Promise<SimpleMap[]> {
-    return await axios.get(API_URL + "/private/matchedTo", {
+    return await axios.get(API_URL + "/matchedTo", {
       params: {
         iri: iri
       }
@@ -22,13 +22,13 @@ const ConceptService = {
   },
 
   async getEntityTermCodes(iri: string, includeInactive?: boolean): Promise<TermCode[]> {
-    return await axios.get(API_URL + "/private/termCode", {
+    return await axios.get(API_URL + "/termCode", {
       params: { iri: iri, includeInactive: includeInactive }
     });
   },
 
   async getContextMaps(conceptIri: string): Promise<ConceptContextMap[]> {
-    return await axios.get(API_URL + "/private/conceptContextMaps", {
+    return await axios.get(API_URL + "/conceptContextMaps", {
       params: { iri: conceptIri }
     });
   }

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -1,13 +1,12 @@
-import { Graph } from "@/interfaces/AutoGen";
 import axios from "axios";
 import Env from "./Env";
 import { Namespace } from "@/interfaces/AutoGen";
 
-const API_URL = Env.API + "api/config";
+const API_URL = Env.API + "api/config/public";
 
 const ConfigService = {
   async getNamespaces(): Promise<Namespace[]> {
-    return await axios.get(API_URL + "/public/namespaces");
+    return await axios.get(API_URL + "/namespaces");
   }
 };
 

--- a/src/services/DataModelService.ts
+++ b/src/services/DataModelService.ts
@@ -2,11 +2,11 @@ import Env from "./Env";
 import axios from "axios";
 import { TTIriRef, NodeShape } from "@/interfaces/AutoGen";
 import { PropertyDisplay, UIProperty } from "@/interfaces";
-const API_URL = Env.API + "api/dataModel";
+const API_URL = Env.API + "api/dataModel/protected";
 
 const DataModelService = {
   async getDataModelProperties(iri: string, pathsOnly?: boolean): Promise<NodeShape> {
-    return await axios.get(API_URL + "/private/dataModelProperties", {
+    return await axios.get(API_URL + "/dataModelProperties", {
       params: {
         iri: iri,
         ...(pathsOnly !== undefined && { pathsOnly: pathsOnly })
@@ -14,34 +14,30 @@ const DataModelService = {
     });
   },
   async getDataModelPropertiesWithValueType(iris: string[], valueType: string): Promise<NodeShape[]> {
-    return await axios.get(API_URL + "/private/dataModelPropertiesWithValueType", {
+    return await axios.get(API_URL + "/dataModelPropertiesWithValueType", {
       params: {
         iris: iris.join(","),
         valueType: valueType
       }
     });
   },
-  async getDatatypes(): Promise<TTIriRef[]> {
-    return await axios.get(API_URL + "/public/datatypes");
-  },
-
   async getDataModelsFromProperty(propIri: string): Promise<TTIriRef[]> {
-    return await axios.get(API_URL + "/private/dataModels", {
+    return await axios.get(API_URL + "/dataModels", {
       params: {
         propIri: propIri
       }
     });
   },
   async checkPropertyType(iri: string): Promise<string> {
-    return await axios.get(API_URL + "/private/checkPropertyType", { params: { iri: iri } });
+    return await axios.get(API_URL + "/checkPropertyType", { params: { iri: iri } });
   },
 
   async getUIProperty(dmIri: string, propIri: string): Promise<UIProperty> {
-    return await axios.get(API_URL + "/private/UIPropertyForQB", { params: { dmIri: dmIri, propIri: propIri } });
+    return await axios.get(API_URL + "/UIPropertyForQB", { params: { dmIri: dmIri, propIri: propIri } });
   },
 
   async getPropertiesDisplay(iri: string): Promise<PropertyDisplay[]> {
-    return await axios.get(API_URL + "/private/propertiesDisplay", {
+    return await axios.get(API_URL + "/propertiesDisplay", {
       params: { iri: iri }
     });
   }

--- a/src/services/EclService.ts
+++ b/src/services/EclService.ts
@@ -2,23 +2,23 @@ import axios from "axios";
 import Env from "./Env";
 import { Query, SearchResponse, ECLQueryRequest } from "@/interfaces/AutoGen";
 
-const API_URL = Env.API + "api/ecl";
+const API_URL = Env.API + "api/ecl/protected";
 
 const EclService = {
   async ECLSearch(eclSearchRequest: ECLQueryRequest, controller?: AbortController): Promise<SearchResponse> {
-    const results: SearchResponse = await axios.post(API_URL + "/private/eclSearch", eclSearchRequest, {
+    const results: SearchResponse = await axios.post(API_URL + "/eclSearch", eclSearchRequest, {
       signal: controller?.signal
     });
     return results;
   },
 
   async getEcl(query: Query): Promise<string> {
-    return await axios.post(API_URL + "/private/ecl", { query: query });
+    return await axios.post(API_URL + "/ecl", { query: query });
   },
 
   async getQueryFromECL(ecl: string, raw: boolean = false): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/queryFromEcl",
+      API_URL + "/queryFromEcl",
       { ecl: ecl, status: { valid: true } },
       { headers: { "Content-Type": "application/json" }, raw: raw }
     );
@@ -26,7 +26,7 @@ const EclService = {
 
   async getEclFromEcl(ecl: string, showNames: boolean): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/eclFromEcl",
+      API_URL + "/eclFromEcl",
       { ecl: ecl, showNames: showNames, status: { valid: true } },
       { headers: { "Content-Type": "application/json" }, raw: true }
     );
@@ -34,7 +34,7 @@ const EclService = {
 
   async validateECL(ecl: string, showNames: boolean): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/validateEcl",
+      API_URL + "/validateEcl",
       { ecl: ecl, showNames: showNames, status: { valid: true } },
       { headers: { "Content-Type": "application/json" } }
     );
@@ -42,35 +42,35 @@ const EclService = {
 
   async validateModelFromECL(ecl: string, showNames: boolean): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/validateModelFromECL",
+      API_URL + "/validateModelFromECL",
       { ecl: ecl, showNames: showNames, status: { valid: true } },
       { headers: { "Content-Type": "application/json" }, raw: true }
     );
   },
   async validateModelFromQuery(query: Query): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/validateModelFromQuery",
+      API_URL + "/validateModelFromQuery",
       { query: query, status: { valid: true } },
       { headers: { "Content-Type": "application/json" }, raw: true }
     );
   },
 
   async getPropertiesForDomains(conceptIri: string[], controller?: AbortController): Promise<string[]> {
-    return await axios.get(API_URL + "/private/propertiesForDomains", {
+    return await axios.get(API_URL + "/propertiesForDomains", {
       params: { conceptIri: conceptIri.join(",") },
       signal: controller?.signal
     });
   },
 
   async isValidPropertyForDomains(propertyIri: string, conceptIri: string[], controller?: AbortController): Promise<string[]> {
-    return await axios.get(API_URL + "/private/isValidPropertyForDomains", {
+    return await axios.get(API_URL + "/isValidPropertyForDomains", {
       params: { propertyIri: propertyIri, conceptIri: conceptIri.join(",") },
       signal: controller?.signal
     });
   },
 
   async getRangesForProperty(propertyIri: string, controller?: AbortController): Promise<string[]> {
-    return await axios.get(API_URL + "/private/rangesForProperty", {
+    return await axios.get(API_URL + "/rangesForProperty", {
       params: { propertyIri: propertyIri },
       signal: controller?.signal
     });
@@ -78,7 +78,7 @@ const EclService = {
 
   async getECLFromQuery(query: Query, showNames?: boolean): Promise<ECLQueryRequest> {
     return await axios.post(
-      API_URL + "/private/eclFromQuery",
+      API_URL + "/eclFromQuery",
       { query: query, showNames: showNames },
       { headers: { "Content-Type": "application/json" }, raw: true }
     );

--- a/src/services/EntityService.ts
+++ b/src/services/EntityService.ts
@@ -6,7 +6,6 @@ import {
   DownloadByQueryOptions,
   Pageable,
   EntityValidationRequest,
-  EntityReferenceNode,
   EditRequest
 } from "@/interfaces/AutoGen";
 import Env from "./Env";
@@ -16,85 +15,17 @@ import { isObjectHasKeys } from "@/helpers/DataTypeCheckers";
 import { buildDetails } from "@/helpers/DetailsBuilder";
 import { OrganizationChartNode } from "primevue/organizationchart";
 import { ExtendedEntityReferenceNode, TTBundle, TTEntity } from "@/interfaces/ExtendedAutoGen";
+
 const API_URL = Env.API + "api/entity";
 
 const EntityService = {
-  async getPartialEntity(iri: string, predicates: string[]): Promise<TTEntity> {
-    return await axios.get(API_URL + "/private/partial", {
-      params: {
-        iri: iri,
-        predicates: predicates.join(",")
-      }
-    });
+  // ============================ PUBLIC ============================
+  async getSchemes(): Promise<{ [x: string]: Namespace }> {
+    return await axios.get(API_URL + "/public/schemes");
   },
 
-  async getFullEntity(iri: string, includeInactiveTermCodes: boolean = false): Promise<TTEntity> {
-    return await axios.get(API_URL + "/fullEntity", {
-      params: {
-        iri: iri,
-        includeInactiveTermCodes: includeInactiveTermCodes
-      }
-    });
-  },
-
-  async getEntityTypes(iri: string): Promise<string[]> {
-    return await axios.get(API_URL + "/entityTypes", {
-      params: {
-        iri: iri
-      }
-    });
-  },
-
-  async getPartialEntityBundle(iri: string, predicates: string[]): Promise<TTBundle> {
-    return await axios.get(API_URL + "/private/partialBundle", {
-      params: {
-        iri: iri,
-        predicates: predicates.join(",")
-      }
-    });
-  },
-
-  async iriExists(iri: string): Promise<boolean> {
-    return await axios.get(API_URL + "/private/iriExists", { params: { iri: iri } });
-  },
-
-  async getFolderPath(iri: string): Promise<TTIriRef[]> {
-    return await axios.get(API_URL + "/private/folderPath", {
-      params: { iri: iri }
-    });
-  },
-
-  async getEntityParents(iri: string, filters?: FiltersAsIris): Promise<ExtendedEntityReferenceNode[]> {
-    return await axios.get(API_URL + "/private/parents", {
-      params: { iri: iri, schemeIris: filters?.schemes.join(",") }
-    });
-  },
-
-  async getEntityChildren(iri: string, filters?: FiltersAsIris, controller?: AbortController): Promise<ExtendedEntityReferenceNode[]> {
-    return await axios.get(API_URL + "/private/children", {
-      params: { iri: iri, schemeIris: filters?.schemes.join(",") },
-      signal: controller?.signal
-    });
-  },
-
-  async getChildEntities(iri: string): Promise<string[]> {
-    return await axios.get(API_URL + "/private/childIris", {
-      params: { iri: iri }
-    });
-  },
-
-  async getPagedChildren(
-    iri: string,
-    pageIndex: number,
-    pageSize: number,
-    filters?: FiltersAsIris,
-    controller?: AbortController,
-    typeFilter?: string[]
-  ): Promise<{ totalCount: number; currentPage: number; pageSize: number; result: TTEntity[] }> {
-    return await axios.get(API_URL + "/private/childrenPaged", {
-      params: { iri: iri, page: pageIndex, size: pageSize, schemeIris: filters?.schemes.join(","), typeFilter: typeFilter?.join(",") },
-      signal: controller?.signal
-    });
+  async getNamespaces(): Promise<Namespace[]> {
+    return await axios.get(API_URL + "/public/namespaces");
   },
 
   async getFilterOptions(): Promise<FilterOptions> {
@@ -105,59 +36,74 @@ const EntityService = {
     return await axios.get(API_URL + "/public/filterDefaults");
   },
 
-  async getCoreSchemes(): Promise<string[]> {
-    const coreSchemesChildren = (await this.getEntityChildren(IM.ECL_BUILDER_SCHEMES)) ?? [];
-    return coreSchemesChildren.map(child => child.iri);
-  },
+  // ============================ PROTECTED ============================
 
-  async getEntityUsages(iri: string, pageIndex: number, pageSize: number): Promise<TTEntity[]> {
-    return await axios.get(API_URL + "/private/usages", {
+  async getPartialEntity(iri: string, predicates: string[]): Promise<TTEntity> {
+    return await axios.get(API_URL + "/protected/partial", {
       params: {
         iri: iri,
-        page: pageIndex,
-        size: pageSize
+        predicates: predicates.join(",")
       }
     });
   },
 
-  async getUsagesTotalRecords(iri: string): Promise<number> {
-    return await axios.get(API_URL + "/private/usagesTotalRecords", {
+  async getPartialEntities(typeIris: string[], predicates: string[]): Promise<TTEntity[]> {
+    return await axios.post(API_URL + "/protected/partials", { iris: [...new Set(typeIris)].join(","), predicates: [...new Set(predicates)].join(",") });
+  },
+
+  async getFullEntity(iri: string, includeInactiveTermCodes: boolean = false): Promise<TTEntity> {
+    return await axios.get(API_URL + "/protected/fullEntity", {
+      params: {
+        iri: iri,
+        includeInactiveTermCodes: includeInactiveTermCodes
+      }
+    });
+  },
+
+  async getEntityTypes(iri: string): Promise<string[]> {
+    return await axios.get(API_URL + "/protected/entityTypes", {
       params: {
         iri: iri
       }
     });
   },
 
-  async getEntitySummary(iri: string): Promise<SearchResultSummary> {
-    return await axios.get(API_URL + "/private/summary", {
-      params: { iri: iri }
+  async getPartialEntityBundle(iri: string, predicates: string[]): Promise<TTBundle> {
+    return await axios.get(API_URL + "/protected/partialBundle", {
+      params: {
+        iri: iri,
+        predicates: predicates.join(",")
+      }
     });
   },
 
-  async getNamespaces(): Promise<Namespace[]> {
-    return await axios.get(API_URL + "/public/namespaces");
-  },
-
-  async getPartialEntities(typeIris: string[], predicates: string[]): Promise<TTEntity[]> {
-    return await axios.post(API_URL + "/private/partials", { iris: [...new Set(typeIris)].join(","), predicates: [...new Set(predicates)].join(",") });
-  },
-
-  async getPathBetweenNodes(descendant: string, ancestor: string): Promise<TTIriRef[]> {
-    return await axios.get(API_URL + "/private/shortestParentHierarchy", {
-      params: { descendant: descendant, ancestor: ancestor }
+  async getEntityChildren(iri: string, filters?: FiltersAsIris, controller?: AbortController): Promise<ExtendedEntityReferenceNode[]> {
+    return await axios.get(API_URL + "/protected/children", {
+      params: { iri: iri, schemeIris: filters?.schemes.join(",") },
+      signal: controller?.signal
     });
   },
 
   async getEntityAsEntityReferenceNode(iri: string): Promise<ExtendedEntityReferenceNode> {
-    return await axios.get(API_URL + "/private/asEntityReferenceNode", { params: { iri: iri } });
-  },
-
-  async getAllowableChildTypes(iri: string): Promise<TTEntity[]> {
-    return await axios.get(API_URL + "/private/allowableChildTypes", { params: { iri: iri } });
+    return await axios.get(API_URL + "/protected/asEntityReferenceNode", { params: { iri: iri } });
   },
 
   async getAsEntityReferenceNodes(iris: string[]): Promise<ExtendedEntityReferenceNode[]> {
-    return await axios.get(API_URL + "/private/asEntityReferenceNodes", { params: { iris: iris.join(",") } });
+    return await axios.get(API_URL + "/protected/asEntityReferenceNodes", { params: { iris: iris.join(",") } });
+  },
+
+  async getPagedChildren(
+    iri: string,
+    pageIndex: number,
+    pageSize: number,
+    filters?: FiltersAsIris,
+    controller?: AbortController,
+    typeFilter?: string[]
+  ): Promise<{ totalCount: number; currentPage: number; pageSize: number; result: TTEntity[] }> {
+    return await axios.get(API_URL + "/protected/childrenPaged", {
+      params: { iri: iri, page: pageIndex, size: pageSize, schemeIris: filters?.schemes.join(","), typeFilter: typeFilter?.join(",") },
+      signal: controller?.signal
+    });
   },
 
   async getPartialAndTotalCount(
@@ -168,81 +114,141 @@ const EntityService = {
     filters?: FiltersAsIris,
     controller?: AbortController
   ): Promise<Pageable<TTIriRef>> {
-    return await axios.get(API_URL + "/private/partialAndTotalCount", {
+    return await axios.get(API_URL + "/protected/partialAndTotalCount", {
       params: { iri: iri, predicate: predicate, page: pageIndex, size: pageSize, schemeIris: filters?.schemes.join(",") },
       signal: controller?.signal
     });
   },
 
+  async downloadEntity(iri: string) {
+    return await axios.get(API_URL + "/protected/downloadEntity", { params: { iri: iri }, responseType: "blob", raw: true });
+  },
+
+  async getEntityParents(iri: string, filters?: FiltersAsIris): Promise<ExtendedEntityReferenceNode[]> {
+    return await axios.get(API_URL + "/protected/parents", {
+      params: { iri: iri, schemeIris: filters?.schemes.join(",") }
+    });
+  },
+
+  async getEntityUsages(iri: string, pageIndex: number, pageSize: number): Promise<TTEntity[]> {
+    return await axios.get(API_URL + "/protected/usages", {
+      params: {
+        iri: iri,
+        page: pageIndex,
+        size: pageSize
+      }
+    });
+  },
+
+  async getUsagesTotalRecords(iri: string): Promise<number> {
+    return await axios.get(API_URL + "/protected/usagesTotalRecords", {
+      params: {
+        iri: iri
+      }
+    });
+  },
+
+  async entityExists(iri: string): Promise<boolean> {
+    return await axios.get(API_URL + "/protected/entityExists", { params: { iri: iri } });
+  },
+
+  async iriExists(iri: string): Promise<boolean> {
+    return await axios.get(API_URL + "/protected/iriExists", { params: { iri: iri } });
+  },
+
+  async getEntitySummary(iri: string): Promise<SearchResultSummary> {
+    return await axios.get(API_URL + "/protected/summary", {
+      params: { iri: iri }
+    });
+  },
+
+  async downloadSearchResults(downloadSettings: DownloadByQueryOptions) {
+    return await axios.post(API_URL + "/protected/downloadSearchResults", downloadSettings, { responseType: "blob", raw: true });
+  },
+
+  async getFolderPath(iri: string): Promise<TTIriRef[]> {
+    return await axios.get(API_URL + "/protected/folderPath", {
+      params: { iri: iri }
+    });
+  },
+
+  async getPathBetweenNodes(descendant: string, ancestor: string): Promise<TTIriRef[]> {
+    return await axios.get(API_URL + "/protected/shortestParentHierarchy", {
+      params: { descendant: descendant, ancestor: ancestor }
+    });
+  },
+
   async getEntityByPredicateExclusions(iri: string, predicates: string[]): Promise<TTEntity> {
-    return await axios.get(API_URL + "/private/entityByPredicateExclusions", {
+    return await axios.get(API_URL + "/protected/entityByPredicateExclusions", {
       params: { iri: iri, predicates: predicates.join(",") }
     });
   },
 
   async getBundleByPredicateExclusions(iri: string, predicates: string[], graph?: string): Promise<TTBundle> {
-    return await axios.get(API_URL + "/private/bundleByPredicateExclusions", {
+    return await axios.get(API_URL + "/protected/bundleByPredicateExclusions", {
       params: { iri: iri, predicates: predicates.join(","), graph: graph }
     });
   },
 
-  async checkExists(iri: string): Promise<boolean> {
-    return await axios.get(API_URL + "/checkExists", { params: { iri: iri } });
-  },
-
-  async createEntity(editRequest: EditRequest): Promise<TTEntity> {
-    return await axios.post(API_URL + "/create", editRequest);
-  },
-
-  async updateEntity(editRequest: EditRequest): Promise<TTEntity> {
-    return await axios.post(API_URL + "/update", editRequest);
-  },
-
   async getValidatedEntitiesBySnomedCodes(codes: string[]): Promise<ValidatedEntity[]> {
-    return await axios.post(API_URL + "/private/validatedEntity", codes);
+    return await axios.post(API_URL + "/protected/validatedEntity", codes);
   },
 
   async getEntityDetailsDisplay(iri: string): Promise<TreeNode[]> {
-    const response: TTBundle = await axios.get(API_URL + "/private/detailsDisplay", { params: { iri: iri } });
+    const response: TTBundle = await axios.get(API_URL + "/protected/detailsDisplay", { params: { iri: iri } });
     return buildDetails(response);
   },
 
   async loadMoreDetailsDisplay(iri: string, predicate: string, pageIndex: number, pageSize: number): Promise<TreeNode[]> {
-    const response: TTBundle = await axios.get(API_URL + "/private/detailsDisplay/loadMore", {
+    const response: TTBundle = await axios.get(API_URL + "/protected/detailsDisplay/loadMore", {
       params: { iri: iri, predicate: predicate, pageIndex: pageIndex, pageSize: pageSize }
     });
     return buildDetails(response);
   },
 
-  async downloadEntity(iri: string) {
-    return await axios.get(API_URL + "/private/downloadEntity", { params: { iri: iri }, responseType: "blob", raw: true });
+  async checkValidation(validationIri: string, data: EntityValidationRequest): Promise<{ valid: boolean; message: string | undefined }> {
+    return await axios.post(API_URL + "/protected/validate", { validationIri: validationIri, entity: data });
   },
 
-  async downloadSearchResults(downloadSettings: DownloadByQueryOptions) {
-    return await axios.post(API_URL + "/private/downloadSearchResults", downloadSettings, { responseType: "blob", raw: true });
+  async getEntityGraph(iri: string): Promise<OrganizationChartNode> {
+    return await axios.get(API_URL + "/protected/graph", { params: { iri: iri } });
+  },
+
+  async getProvHistory(iri: string): Promise<TTEntity[]> {
+    return await axios.get(API_URL + "/protected/history", {
+      params: { iri: iri }
+    });
+  },
+
+  async getAllowableChildTypes(iri: string): Promise<TTEntity[]> {
+    return await axios.get(API_URL + "/protected/allowableChildTypes", { params: { iri: iri } });
+  },
+
+  async getChildEntities(iri: string): Promise<string[]> {
+    return await axios.get(API_URL + "/protected/childIris", {
+      params: { iri: iri }
+    });
+  },
+
+  // ========================== PRIVATE ==========================
+
+  async createEntity(editRequest: EditRequest): Promise<TTEntity> {
+    return await axios.post(API_URL + "/private/create", editRequest);
+  },
+
+  async updateEntity(editRequest: EditRequest): Promise<TTEntity> {
+    return await axios.post(API_URL + "/private/update", editRequest);
+  },
+  // ========================== HELPERS ==========================
+
+  async getCoreSchemes(): Promise<string[]> {
+    const coreSchemesChildren = (await this.getEntityChildren(IM.ECL_BUILDER_SCHEMES)) ?? [];
+    return coreSchemesChildren.map(child => child.iri);
   },
 
   async getName(iri: string): Promise<string | undefined> {
     const result = await EntityService.getPartialEntity(iri, [RDFS.LABEL]);
     if (isObjectHasKeys(result, [RDFS.LABEL])) return result[RDFS.LABEL];
-  },
-
-  async checkValidation(validationIri: string, data: EntityValidationRequest): Promise<{ valid: boolean; message: string | undefined }> {
-    return await axios.post(API_URL + "/private/validate", { validationIri: validationIri, entity: data });
-  },
-
-  async getSchemes(): Promise<{ [x: string]: Namespace }> {
-    return await axios.get(API_URL + "/private/schemes");
-  },
-
-  async getEntityGraph(iri: string): Promise<OrganizationChartNode> {
-    return await axios.get(API_URL + "/private/graph", { params: { iri: iri } });
-  },
-
-  async getProvHistory(iri: string): Promise<TTEntity[]> {
-    return await axios.get(API_URL + "/private/history", {
-      params: { iri: iri }
-    });
   }
 };
 if (process.env.NODE_ENV !== "test") Object.freeze(EntityService);

--- a/src/services/FilerService.ts
+++ b/src/services/FilerService.ts
@@ -1,9 +1,9 @@
-import { Graph, TTDocument } from "@/interfaces/AutoGen";
+import { TTDocument } from "@/interfaces/AutoGen";
 import Env from "./Env";
 import axios from "axios";
 import { TTEntity } from "@/interfaces/ExtendedAutoGen";
 import { Namespace } from "@/vocabulary/Namespace";
-const API_URL = Env.API + "api/filer";
+const API_URL = Env.API + "api/filer/private";
 const FilerService = {
   async moveFolder(entity: string, oldFolder: string, newFolder: string): Promise<void> {
     return await axios.post(API_URL + "/folder/move", null, {

--- a/src/services/FunctionService.ts
+++ b/src/services/FunctionService.ts
@@ -3,12 +3,12 @@ import Env from "./Env";
 import { isArrayHasLength } from "@/helpers/DataTypeCheckers";
 import { Argument } from "@/interfaces/AutoGen";
 
-const API_URL = Env.API + "api/function";
+const API_URL = Env.API + "api/function/protected";
 
 const FunctionService = {
   async runFunction(iri: string, args?: Argument[]): Promise<any> {
     if (args && args.length > 0) {
-      const result: any = await axios.post(API_URL + "/private/callFunction", {
+      const result: any = await axios.post(API_URL + "/callFunction", {
         functionIri: iri,
         arguments: args
       });
@@ -17,7 +17,7 @@ const FunctionService = {
         if (found && found.valueData) return result[found.valueData];
         else return result;
       } else return result;
-    } else return await axios.post(API_URL + "/private/callFunction", { functionIri: iri });
+    } else return await axios.post(API_URL + "/callFunction", { functionIri: iri });
   }
 };
 

--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -14,7 +14,7 @@ const GithubService = {
   },
 
   async updateGithubConfig(): Promise<void> {
-    return await axios.post(API_URL + "/updateGithubConfig", { raw: true });
+    return await axios.post(API_URL + "/private/updateGithubConfig", { raw: true });
   }
 };
 

--- a/src/services/QueryService.ts
+++ b/src/services/QueryService.ts
@@ -2,13 +2,11 @@ import Env from "./Env";
 import { QueryResponse } from "@/interfaces";
 import axios from "axios";
 import {
-  DBEntry,
   DisplayMode,
   Match,
   PathQuery,
   Query,
   QueryRequest,
-  RequeueQueryRequest,
   SearchResponse,
   ArgumentReference,
   IMLLanguage,
@@ -17,67 +15,67 @@ import {
 } from "@/interfaces/AutoGen";
 import { isArrayHasLength, isObjectHasKeys } from "@/helpers/DataTypeCheckers";
 import { TTEntity } from "@/interfaces/ExtendedAutoGen";
-const API_URL = Env.API + "api/query";
+const API_URL = Env.API + "api/query/protected";
 
 const QueryService = {
   async queryIM(query: QueryRequest, controller?: AbortController, raw: boolean = false): Promise<QueryResponse> {
-    if (controller) return await axios.post(API_URL + "/private/queryIM", query, { signal: controller.signal, raw: raw });
-    else return await axios.post(API_URL + "/private/queryIM", query, { raw: raw });
+    if (controller) return await axios.post(API_URL + "/queryIM", query, { signal: controller.signal, raw: raw });
+    else return await axios.post(API_URL + "/queryIM", query, { raw: raw });
   },
   async flattenBooleans(query: Query | Match): Promise<Query | Match> {
-    return await axios.post(API_URL + "/private/flattenBooleans", query);
+    return await axios.post(API_URL + "/flattenBooleans", query);
   },
   async optimiseECLQuery(query: Query): Promise<Query> {
-    return await axios.post(API_URL + "/private/optimiseECLQuery", query);
+    return await axios.post(API_URL + "/optimiseECLQuery", query);
   },
 
   async queryIMSearch(query: QueryRequest, controller?: AbortController, raw: boolean = false): Promise<SearchResponse> {
-    return await axios.post(API_URL + "/private/queryIMSearch", query, { signal: controller?.signal, raw: raw });
+    return await axios.post(API_URL + "/queryIMSearch", query, { signal: controller?.signal, raw: raw });
   },
 
   async pathQuery(pathQuery: PathQuery, controller?: AbortController, raw: boolean = false): Promise<{ match: Match[] }> {
-    return await axios.post(API_URL + "/private/pathQuery", pathQuery, { signal: controller?.signal, raw: raw });
+    return await axios.post(API_URL + "/pathQuery", pathQuery, { signal: controller?.signal, raw: raw });
   },
 
   async askQuery(query: QueryRequest, controller?: AbortController, raw: boolean = false): Promise<boolean> {
-    return await axios.post(API_URL + "/private/askQueryIM", query, { signal: controller?.signal, raw: raw });
+    return await axios.post(API_URL + "/askQueryIM", query, { signal: controller?.signal, raw: raw });
   },
 
   async getQueryDisplay(iri: string, includeLogicDesc: boolean): Promise<Query> {
-    return await axios.get(API_URL + "/private/queryDisplay", { params: { queryIri: iri, includeLogicDesc: includeLogicDesc } });
+    return await axios.get(API_URL + "/queryDisplay", { params: { queryIri: iri, includeLogicDesc: includeLogicDesc } });
   },
 
   async getQueryDisplayFromQuery(query: Query, displayMode: DisplayMode): Promise<Query> {
-    return await axios.post(API_URL + "/private/queryDisplayFromQuery", { query: query, displayMode: displayMode });
+    return await axios.post(API_URL + "/queryDisplayFromQuery", { query: query, displayMode: displayMode });
   },
 
   async getDisplayFromQueryIri(iri: string, displayMode: DisplayMode): Promise<Query> {
-    return await axios.get(API_URL + "/private/queryDisplay", { params: { queryIri: iri, displayMode: displayMode } });
+    return await axios.get(API_URL + "/queryDisplay", { params: { queryIri: iri, displayMode: displayMode } });
   },
   async getQueryFromIri(iri: string): Promise<Query> {
-    return await axios.get(API_URL + "/private/queryFromIri", { params: { queryIri: iri } });
+    return await axios.get(API_URL + "/queryFromIri", { params: { queryIri: iri } });
   },
 
   async getDisplayFromIndicatorIri(iri: string): Promise<Indicator> {
-    return await axios.get(API_URL + "/private/indicatorDisplay", { params: { queryIri: iri } });
+    return await axios.get(API_URL + "/indicatorDisplay", { params: { queryIri: iri } });
   },
 
   async expandCohort(queryIri: string, cohortIri: string, displayMode: DisplayMode): Promise<Query> {
-    return await axios.get(API_URL + "/private/expandCohort", { params: { queryIri: queryIri, cohortIri: cohortIri, displayMode: displayMode } });
+    return await axios.get(API_URL + "/expandCohort", { params: { queryIri: queryIri, cohortIri: cohortIri, displayMode: displayMode } });
   },
 
   async getDefaultQuery(): Promise<Query> {
-    return await axios.get(API_URL + "/private/defaultQuery");
+    return await axios.get(API_URL + "/defaultQuery");
   },
   async generateQuerySQL(queryIri: string, lang?: string): Promise<string> {
-    return await axios.get(API_URL + "/private/sql", { params: { queryIri: queryIri, lang: lang } });
+    return await axios.get(API_URL + "/sql", { params: { queryIri: queryIri, lang: lang } });
   },
 
   async generateQueryIML(queryIri: string): Promise<IMLLanguage> {
-    return await axios.get(API_URL + "/private/imlFromIri", { params: { queryIri: queryIri } });
+    return await axios.get(API_URL + "/imlFromIri", { params: { queryIri: queryIri } });
   },
   async generateQuerySQLfromQuery(query: Query): Promise<string> {
-    return await axios.post(API_URL + "/private/sql", query);
+    return await axios.post(API_URL + "/sql", query);
   },
 
   async validateSelectionWithQuery(selectedIri: string, queryRequest: QueryRequest): Promise<boolean> {
@@ -102,7 +100,7 @@ const QueryService = {
   },
 
   async getNestedReturns(match: Match): Promise<Return[]> {
-    return await axios.post(API_URL + "/private/nestedReturns", { match: match });
+    return await axios.post(API_URL + "/nestedReturns", { match: match });
   }
 };
 

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -6,39 +6,38 @@ import { User } from "@/interfaces";
 const API_URL = Env.API + "api/security";
 
 const SecurityService = {
-  async getLoginUrl(redirectUrl?: string): Promise<string> {
-    if (!redirectUrl) redirectUrl = Env.DIRECTORY_URL + "callback";
-    return await axios.get(API_URL + "/public/loginUrl", { params: { redirectUrl: redirectUrl } });
-  },
-
   async getRegisterUrl(redirectUrl?: string): Promise<string> {
     if (!redirectUrl) redirectUrl = Env.DIRECTORY_URL + "callback";
     return await axios.get(API_URL + "/public/registerUrl", { params: { redirectUrl: redirectUrl } });
   },
 
-  async login(code: string, state: string):Promise<{user:User,state:string|undefined}> {
+  async getLoginUrl(redirectUrl?: string): Promise<string> {
+    if (!redirectUrl) redirectUrl = Env.DIRECTORY_URL + "callback";
+    return await axios.get(API_URL + "/public/loginUrl", { params: { redirectUrl: redirectUrl } });
+  },
+
+  async login(code: string, state: string): Promise<{ user: User; state: string | undefined }> {
     return await axios.get(API_URL + "/public/login", { params: { code: code, state: state } });
   },
 
   async logout() {
-    await axios.get(API_URL + "/public/logout");
+    await axios.get(API_URL + "/private/logout");
+  },
+  async adminGetUsersByGroup(group: UserRole): Promise<User[]> {
+    return await axios.get(API_URL + "/private/getUsersInGroup", { params: { group: group } });
+  },
+  async adminGetGroups(): Promise<UserRole[]> {
+    return await axios.get(API_URL + "/private/getGroups");
   },
 
   async getUser(raw?: boolean): Promise<User> {
-    return await axios.get(API_URL + "/user", { raw: raw });
+    return await axios.get(API_URL + "/private/user", { raw: raw });
   },
 
   async getProfileUrl(): Promise<string> {
-    return await axios.get(API_URL + "/user/profileUrl");
+    return await axios.get(API_URL + "/private/user/profileUrl");
   },
 
-  async adminGetUsersByGroup(group: UserRole): Promise<User[]> {
-    return await axios.get(API_URL + "/getUsersInGroup", { params: { group: group } });
-  },
-
-  async adminGetGroups(): Promise<UserRole[]> {
-    return await axios.get(API_URL + "/getGroups");
-  }
 };
 
 if (process.env.NODE_ENV !== "test") Object.freeze(SecurityService);

--- a/src/services/SetService.ts
+++ b/src/services/SetService.ts
@@ -7,7 +7,7 @@ const API_URL = Env.API + "api/set";
 
 const SetService = {
   async publish(conceptIri: string) {
-    return await axios.get(API_URL + "/publish", {
+    return await axios.get(API_URL + "/private/publish", {
       params: { iri: conceptIri }
     });
   },
@@ -20,7 +20,7 @@ const SetService = {
     });
   },
   async getMembers(iri: string, entailments: boolean, pageIndex: number, pageSize: number, controller?: AbortController): Promise<Pageable<Node>> {
-    return await axios.get(API_URL + "/private/members", {
+    return await axios.get(API_URL + "/protected/members", {
       params: { iri: iri, entailments: entailments, page: pageIndex, size: pageSize },
       signal: controller?.signal
     });
@@ -28,35 +28,34 @@ const SetService = {
 
   async getMembersFromQuery(query: Query, pageIndex: number, pageSize: number): Promise<Pageable<Node>> {
     const request = { query: query, page: pageIndex, size: pageSize } as ECLQueryRequest;
-    return await axios.post(API_URL + "/private/membersFromQuery", request);
+    return await axios.post(API_URL + "/protected/membersFromQuery", request);
   },
 
   async getSubsets(iri: string): Promise<TTIriRef[]> {
-    return await axios.get(API_URL + "/private/subsets", {
+    return await axios.get(API_URL + "/protected/subsets", {
       params: {
         iri: iri
       }
     });
   },
 
+  async getFullExportSet(setRequest: SetExportRequest, raw?: boolean): Promise<Blob> {
+    return await axios.post(API_URL + "/protected/setExport", setRequest, {
+      responseType: "blob",
+      raw: raw
+    });
+  },
+
   async getSetComparison(iriA?: string, iriB?: string): Promise<SetDiffObject> {
-    return await axios.get(API_URL + "/private/setDiff", {
+    return await axios.get(API_URL + "/protected/setDiff", {
       params: {
         setIriA: iriA,
         setIriB: iriB
       }
     });
   },
-
-  async getFullExportSet(setRequest: SetExportRequest, raw?: boolean): Promise<Blob> {
-    return await axios.post(API_URL + "/private/setExport", setRequest, {
-      responseType: "blob",
-      raw: raw
-    });
-  },
-
   async updateSubsetsFromSuper(entity: TTEntity) {
-    return await axios.post(API_URL + "/updateSubsetsFromSuper", entity);
+    return await axios.post(API_URL + "/private/updateSubsetsFromSuper", entity);
   }
 };
 

--- a/src/services/StatusService.ts
+++ b/src/services/StatusService.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
 import Env from "./Env";
 
-const API_URL = Env.API + "api/status";
+const API_URL = Env.API + "api/status/public";
 
 const StatusService = {
   async isPublicMode(): Promise<boolean> {
-    return await axios.get(API_URL + "/public/isPublicMode");
+    return await axios.get(API_URL + "/isPublicMode");
   },
 
   async isDevMode(): Promise<boolean> {
-    return await axios.get(API_URL + "/public/isDevMode");
+    return await axios.get(API_URL + "/isDevMode");
   }
 };
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -7,7 +7,7 @@ import PrimeVueColors from "@/enums/PrimeVueColors";
 import { UserData } from "@/interfaces/UserData";
 import { Graph, NamespacePermission, RecentActivityItemDto } from "@/interfaces/AutoGen";
 
-const API_URL = Env.API + "api/user";
+const API_URL = Env.API + "api/user/private";
 
 const UserService = {
   async updateUserPreset(preset: PrimeVuePresetThemes): Promise<User> {

--- a/src/services/WorkflowService.ts
+++ b/src/services/WorkflowService.ts
@@ -2,7 +2,7 @@ import { BugReport, EntityApproval, NamespaceRequest, RoleRequest, Task, Workflo
 import Env from "./Env";
 import axios from "axios";
 
-const API_URL = Env.API + "api/workflow";
+const API_URL = Env.API + "api/workflow/private";
 
 const WorkflowService = {
   async createBugReport(bugReport: BugReport): Promise<void> {


### PR DESCRIPTION
- updated all service api urls to use consistent protected/private prefix patterns
- removed redundant imports and simplified api call signatures
- reorganized service methods into public/protected/private sections for better clarity
- adjusted endpoint paths to remove unnecessary /private/ segments where appropriate
- consolidated duplicate methods and improved code structure across multiple services