### PR TITLE
refactor: migrate vue-library imports to @endeavour scope

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -10,7 +10,7 @@
   "bracketSameLine": false,
   "arrowParens": "avoid",
   "plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],
-  "importOrder": ["^vue$", "^vue-library", "^@?\\w", "^@/", "^[./]"],
+  "importOrder": ["^vue$", "^@endeavour/vue-library", "^@?\\w", "^@/", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/DEVELOPERS.MD
+++ b/DEVELOPERS.MD
@@ -1,0 +1,86 @@
+# IMDirectory Developer Documentation
+
+This document provides a structural overview of the **IMDirectory** project to help developers understand the architecture, key directories, and development workflow.
+
+## 🛠 Technology Stack
+
+- **Framework**: [Vue 3](https://vuejs.org/) (Composition API)
+- **Build Tool**: [Vite](https://vitejs.dev/)
+- **State Management**: [Pinia](https://pinia.vuejs.org/)
+- **Routing**: [Vue Router](https://router.vuejs.org/)
+- **UI Library**: [PrimeVue](https://primevue.org/)
+- **Styling**: [Tailwind CSS](https://tailwindcss.com/) & [Sass](https://sass-lang.com/)
+- **Testing**: [Vitest](https://vitest.dev/) (Unit) & [Gauge](https://gauge.org/)/[Playwright](https://playwright.dev/) (E2E)
+- **API Mocking**: [MSW (Mock Service Worker)](https://mswjs.io/)
+- **Package Manager**: [pnpm](https://pnpm.io/)
+
+## 📂 Project Structure
+
+The codebase follows a standard Vue/Vite structure with logic separated by responsibility:
+
+### Source Directory (`/src`)
+
+- **`components/`**: Reusable Vue components.
+- **`views/`**: Page-level components associated with routes.
+- **`composables/`**: Shared stateful logic using Vue's Composition API.
+- **`stores/`**: Pinia state management modules.
+- **`services/`**: API calls and business logic layer.
+- **`router/`**: Vue Router configuration and navigation guards.
+- **`models/`, `interfaces/`, `enums/`, `typings/`**: TypeScript type definitions and constants.
+- **`helpers/`**: Utility functions and common logic.
+- **`assets/`**: Static assets like images and global styles.
+- **`constants/`**: Application-wide constant values.
+- **`main.ts`**: Application entry point.
+- **`App.vue`**: Root component.
+
+### Other Directories
+
+- **`public/`**: Static files served directly (e.g., icons, mock service worker).
+- **`tests/`**: Unit and E2E test suites.
+- **`.nuxt/`**: Generated types and schema (project may use some Nuxt-like patterns or extensions).
+- **`.github/`**: CI/CD workflows and issue templates.
+- **`docs/`**: Project documentation (including this file).
+
+## 🚀 Development Workflow
+
+### Installation
+```bash
+pnpm install
+```
+
+### Local Development
+Runs the application with hot-reloading:
+```bash
+pnpm dev
+```
+
+### Building for Production
+Compiles and minifies for production:
+```bash
+pnpm build
+```
+
+### Testing
+- **Unit Tests**: `pnpm test:unit`
+- **Coverage**: `pnpm test:coverage`
+- **E2E Tests**: `pnpm test:e2e`
+
+### Linting & Formatting
+- **Lint**: `pnpm lint`
+- **Format**: `pnpm format`
+
+## 🔌 API Interaction
+
+The project expects the **IMAPI** to be running on `localhost:8080` for local development. Environment variables are managed via a `.env` file in the root.
+
+- **Hosting Mode**: `VITE_HOSTING_MODE="public"` or `"private"`
+
+## 🎨 UI & Styling
+
+- **PrimeVue**: used for high-level UI components.
+- **Tailwind CSS**: used for utility-first styling.
+- **Sass**: used for custom complex styles.
+- **FontAwesome Pro**: Integrated for icons (requires specific setup in `index.html`).
+
+---
+*Last updated: April 2026*

--- a/components.d.ts
+++ b/components.d.ts
@@ -65,7 +65,6 @@ declare module 'vue' {
     DirectoryViewerModelChart: typeof import('./src/components/directory/viewer/ModelChart.vue')['default']
     DirectoryViewerProvenance: typeof import('./src/components/directory/viewer/Provenance.vue')['default']
     DirectoryViewerQueryDisplay: typeof import('./src/components/directory/viewer/QueryDisplay.vue')['default']
-    DirectoryViewerQueryDisplayTestQueryResults: typeof import('@/components/query/viewer/TestQueryResults.vue')['default']
     DirectoryViewerSetCompareSetDialog: typeof import('./src/components/directory/viewer/set/CompareSetDialog.vue')['default']
     DirectoryViewerSetCompareSetSection: typeof import('./src/components/directory/viewer/set/CompareSetSection.vue')['default']
     DirectoryViewerSetDefinition: typeof import('./src/components/directory/viewer/set/SetDefinition.vue')['default']

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "format:check": "prettier --list-different \"{src,tests}/**/*.{js,ts,vue,json,css,scss,md}\"",
     "clean-install": "rimraf pnpm-lock.yaml && rimraf node_modules && pnpm install",
     "stop-only": "node stop-only.js",
-    "prepare": "husky",
-    "preinstall": "pnpm add endeavourhealth-discovery/VueLibrary"
+    "prepare": "husky"
   },
   "dependencies": {
     "@braintree/sanitize-url": "7.1.2",
+    "@endeavour/vue-library": "0.1.0",
     "@msw/data": "1.1.2",
     "@primeuix/themes": "2.0.3",
     "@primevue/auto-import-resolver": "4.5.4",
@@ -62,7 +62,6 @@
     "vite-plugin-prismjs": "0.0.11",
     "vue": "3.5.32",
     "vue-json-pretty": "2.6.0",
-    "vue-library": "github:endeavourhealth-discovery/VueLibrary",
     "vue-router": "5.0.4",
     "vue-showdown": "4.2.0",
     "vue3-clipboard": "1.0.0",
@@ -165,8 +164,7 @@
       "core-js",
       "esbuild",
       "msw",
-      "vue-demi",
-      "vue-library"
+      "vue-demi"
     ]
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.12.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.5.2",
   "scripts": {
     "dev": "run-p tsc:dev dev:vite",
     "tsc:dev": "vue-tsc --noEmit --watch",
@@ -20,7 +21,8 @@
     "format:check": "prettier --list-different \"{src,tests}/**/*.{js,ts,vue,json,css,scss,md}\"",
     "clean-install": "rimraf pnpm-lock.yaml && rimraf node_modules && pnpm install",
     "stop-only": "node stop-only.js",
-    "prepare": "husky"
+    "prepare": "husky",
+    "preinstall": "pnpm config set \"@endeavour:registry\" https://artifactory.endhealth.co.uk/repository/npm/"
   },
   "dependencies": {
     "@braintree/sanitize-url": "7.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@braintree/sanitize-url':
         specifier: 7.1.2
         version: 7.1.2
+      '@endeavour/vue-library':
+        specifier: 0.1.0
+        version: 0.1.0(@primeuix/themes@2.0.3)(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(primevue@4.5.5(vue@3.5.32(typescript@6.0.2)))(qrcode@1.5.4)(sortablejs@1.10.2)(typescript-logging@2.2.0)(universal-cookie@7.2.2)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
       '@msw/data':
         specifier: 1.1.2
         version: 1.1.2
@@ -131,9 +134,6 @@ importers:
       vue-json-pretty:
         specifier: 2.6.0
         version: 2.6.0(vue@3.5.32(typescript@6.0.2))
-      vue-library:
-        specifier: github:endeavourhealth-discovery/VueLibrary
-        version: https://codeload.github.com/endeavourhealth-discovery/VueLibrary/tar.gz/361fcf95ba8ce9f4458bd0b0da50780c93c28cc9(@primeuix/themes@2.0.3)(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(primevue@4.5.5(vue@3.5.32(typescript@6.0.2)))(qrcode@1.5.4)(sortablejs@1.10.2)(typescript-logging@2.2.0)(universal-cookie@7.2.2)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
@@ -458,6 +458,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@endeavour/vue-library@0.1.0':
+    resolution: {integrity: sha512-atQR/3SGIEDO1VVW5cwHkLLnOUekIYXkYC5b23icljmqSjXImg3DSD8kA2TdaIKjeK9ztKC7kzcoWVRcsxx20Q==}
+    peerDependencies:
+      '@primeuix/themes': 2.0.3
+      pinia: 3.0.4
+      primevue: 4.5.5
+      vue: 3.5.32
+      vue-router: 5.0.4
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -4517,16 +4526,6 @@ packages:
     peerDependencies:
       vue: '>=3.0.0'
 
-  vue-library@https://codeload.github.com/endeavourhealth-discovery/VueLibrary/tar.gz/361fcf95ba8ce9f4458bd0b0da50780c93c28cc9:
-    resolution: {tarball: https://codeload.github.com/endeavourhealth-discovery/VueLibrary/tar.gz/361fcf95ba8ce9f4458bd0b0da50780c93c28cc9}
-    version: 0.0.0
-    peerDependencies:
-      '@primeuix/themes': 2.0.3
-      pinia: 3.0.4
-      primevue: 4.5.5
-      vue: 3.5.32
-      vue-router: 5.0.4
-
   vue-router@5.0.4:
     resolution: {integrity: sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==}
     peerDependencies:
@@ -4874,6 +4873,36 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@endeavour/vue-library@0.1.0(@primeuix/themes@2.0.3)(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(primevue@4.5.5(vue@3.5.32(typescript@6.0.2)))(qrcode@1.5.4)(sortablejs@1.10.2)(typescript-logging@2.2.0)(universal-cookie@7.2.2)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))':
+    dependencies:
+      '@primeuix/themes': 2.0.3
+      '@vueuse/core': 14.2.1(vue@3.5.32(typescript@6.0.2))
+      '@vueuse/integrations': 14.2.1(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(qrcode@1.5.4)(sortablejs@1.10.2)(universal-cookie@7.2.2)(vue@3.5.32(typescript@6.0.2))
+      google-palette: 1.1.1
+      lodash-es: 4.17.23
+      pinia: 3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
+      primevue: 4.5.5(vue@3.5.32(typescript@6.0.2))
+      sass: 1.99.0
+      typescript-logging-log4ts-style: 2.2.0(typescript-logging@2.2.0)
+      uuid: 13.0.0
+      vue: 3.5.32(typescript@6.0.2)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - focus-trap
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - typescript-logging
+      - universal-cookie
 
   '@epic-web/invariant@1.0.0': {}
 
@@ -9008,36 +9037,6 @@ snapshots:
   vue-json-pretty@2.6.0(vue@3.5.32(typescript@6.0.2)):
     dependencies:
       vue: 3.5.32(typescript@6.0.2)
-
-  vue-library@https://codeload.github.com/endeavourhealth-discovery/VueLibrary/tar.gz/361fcf95ba8ce9f4458bd0b0da50780c93c28cc9(@primeuix/themes@2.0.3)(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(primevue@4.5.5(vue@3.5.32(typescript@6.0.2)))(qrcode@1.5.4)(sortablejs@1.10.2)(typescript-logging@2.2.0)(universal-cookie@7.2.2)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)):
-    dependencies:
-      '@primeuix/themes': 2.0.3
-      '@vueuse/core': 14.2.1(vue@3.5.32(typescript@6.0.2))
-      '@vueuse/integrations': 14.2.1(async-validator@4.2.5)(axios@1.15.0)(change-case@5.4.4)(drauu@0.4.3)(focus-trap@8.0.1)(fuse.js@7.1.0)(idb-keyval@6.2.2)(jwt-decode@4.0.0)(nprogress@0.2.0)(qrcode@1.5.4)(sortablejs@1.10.2)(universal-cookie@7.2.2)(vue@3.5.32(typescript@6.0.2))
-      google-palette: 1.1.1
-      lodash-es: 4.17.23
-      pinia: 3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
-      primevue: 4.5.5(vue@3.5.32(typescript@6.0.2))
-      sass: 1.99.0
-      typescript-logging-log4ts-style: 2.2.0(typescript-logging@2.2.0)
-      uuid: 13.0.0
-      vue: 3.5.32(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - async-validator
-      - axios
-      - change-case
-      - drauu
-      - focus-trap
-      - fuse.js
-      - idb-keyval
-      - jwt-decode
-      - nprogress
-      - qrcode
-      - sortablejs
-      - typescript-logging
-      - universal-cookie
 
   vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)):
     dependencies:

--- a/src/InformationManager.vue
+++ b/src/InformationManager.vue
@@ -23,11 +23,11 @@
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 
-import { useChangeFontSize, useChangeThemeOptions } from "vue-library/composables";
-import { REPO } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { GithubRelease } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { useChangeFontSize, useChangeThemeOptions } from "@endeavour/vue-library/composables";
+import { REPO } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { GithubRelease } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useCookies } from "@vueuse/integrations";
 import axios, { AxiosError, AxiosInstance, AxiosRequestHeaders, AxiosResponse, InternalAxiosRequestConfig } from "axios";

--- a/src/components/adminToolbox/Home.vue
+++ b/src/components/adminToolbox/Home.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { IMFontAwesomeIcon } from "vue-library/components";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
 </script>
 
 <style scoped></style>

--- a/src/components/adminToolbox/github/UpdateConfig.vue
+++ b/src/components/adminToolbox/github/UpdateConfig.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-import { REPO } from "vue-library/enums";
+import { REPO } from "@endeavour/vue-library/enums";
 
 import AlertDialog from "@/components/shared/dynamicDialogs/AlertDialog.vue";
 import { GithubService } from "@/services";

--- a/src/components/app/CookiesConsent.vue
+++ b/src/components/app/CookiesConsent.vue
@@ -39,7 +39,7 @@
 <script lang="ts" setup>
 import { ComputedRef, computed, onMounted, ref, watch } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useSharedStore } from "@/stores/sharedStore";
 

--- a/src/components/app/FooterBar.vue
+++ b/src/components/app/FooterBar.vue
@@ -40,8 +40,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { REPO } from "vue-library/enums";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { REPO } from "@endeavour/vue-library/enums";
 
 import { useRouter } from "vue-router";
 

--- a/src/components/app/ReleaseBannerBar.vue
+++ b/src/components/app/ReleaseBannerBar.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import type { GithubRelease } from "vue-library/interfaces";
+import type { GithubRelease } from "@endeavour/vue-library/interfaces";
 
 import { useSharedStore } from "@/stores/sharedStore";
 

--- a/src/components/app/ReleaseNotes.vue
+++ b/src/components/app/ReleaseNotes.vue
@@ -53,9 +53,9 @@
 <script setup lang="ts">
 import { Ref, nextTick, onMounted, ref } from "vue";
 
-import { REPO } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { GithubRelease } from "vue-library/interfaces";
+import { REPO } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { GithubRelease } from "@endeavour/vue-library/interfaces";
 
 import { sanitizeUrl } from "@braintree/sanitize-url";
 

--- a/src/components/app/SnomedConsent.vue
+++ b/src/components/app/SnomedConsent.vue
@@ -81,7 +81,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import Button from "primevue/button";
 import Dialog from "primevue/dialog";

--- a/src/components/creator/TypeSelector.vue
+++ b/src/components/creator/TypeSelector.vue
@@ -19,8 +19,8 @@
 <script setup lang="ts">
 import { Ref, inject, onMounted, ref } from "vue";
 
-import { RDF } from "vue-library/enums";
-import type { ExtendedEntityReferenceNode, ExtendedTTEntity } from "vue-library/interfaces";
+import { RDF } from "@endeavour/vue-library/enums";
+import type { ExtendedEntityReferenceNode, ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import editorShapes from "@/constants/editorShapes";
 import injectionKeys from "@/injectionKeys/injectionKeys";

--- a/src/components/directory/DirectoryDetails.vue
+++ b/src/components/directory/DirectoryDetails.vue
@@ -38,8 +38,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import type { ExtendedTTEntity, SearchResponse } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import type { ExtendedTTEntity, SearchResponse } from "@endeavour/vue-library/interfaces";
 
 import ParentHeader from "@/components/directory/ParentHeader.vue";
 import ParentHierarchy from "@/components/directory/ParentHierarchy.vue";

--- a/src/components/directory/DirectorySplitter.vue
+++ b/src/components/directory/DirectorySplitter.vue
@@ -44,8 +44,8 @@
 <script setup lang="ts">
 import { Ref, computed, ref } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { FilterOptions, SearchResponse } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { FilterOptions, SearchResponse } from "@endeavour/vue-library/interfaces";
 
 import { SplitterResizeEndEvent } from "primevue/splitter";
 import { useRouter } from "vue-router";

--- a/src/components/directory/EclSearch.vue
+++ b/src/components/directory/EclSearch.vue
@@ -82,10 +82,10 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM } from "vue-library/enums";
-import { byName } from "vue-library/helpers";
-import type { ECLQueryRequest, GenericObject, SearchResultSummary, TTIriRef } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { IM } from "@endeavour/vue-library/enums";
+import { byName } from "@endeavour/vue-library/helpers";
+import type { ECLQueryRequest, GenericObject, SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import ECLBuilder from "@/components/imquery/ECLBuilder.vue";
 import ResultsTable from "@/components/shared/ResultsTable.vue";

--- a/src/components/directory/IMQuerySearch.vue
+++ b/src/components/directory/IMQuerySearch.vue
@@ -35,10 +35,10 @@
 <script setup lang="ts">
 import { Ref, ref } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { ToastSeverity } from "vue-library/enums";
-import type { QueryRequest, SearchResultSummary } from "vue-library/interfaces";
-import { ToastOptions } from "vue-library/models";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { ToastSeverity } from "@endeavour/vue-library/enums";
+import type { QueryRequest, SearchResultSummary } from "@endeavour/vue-library/interfaces";
+import { ToastOptions } from "@endeavour/vue-library/models";
 
 import Button from "primevue/button";
 import Textarea from "primevue/textarea";

--- a/src/components/directory/LandingPage.vue
+++ b/src/components/directory/LandingPage.vue
@@ -26,8 +26,8 @@
 <script setup lang="ts">
 import { Ref, ref } from "vue";
 
-import { IM, NAMESPACE, SHACL } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType } from "vue-library/helpers";
+import { IM, NAMESPACE, SHACL } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType } from "@endeavour/vue-library/helpers";
 
 import Favourites from "@/components/directory/landingPage/Favourites.vue";
 import RecentActivity from "@/components/directory/landingPage/RecentActivity.vue";

--- a/src/components/directory/ParentHeader.vue
+++ b/src/components/directory/ParentHeader.vue
@@ -28,10 +28,10 @@
 </template>
 
 <script setup lang="ts">
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType } from "vue-library/helpers";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import ActionButtons from "@/components/shared/ActionButtons.vue";
 

--- a/src/components/directory/ParentHierarchy.vue
+++ b/src/components/directory/ParentHierarchy.vue
@@ -28,8 +28,8 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import type { TTIriRef } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { MenuItem } from "primevue/menuitem";
 

--- a/src/components/directory/Viewer.vue
+++ b/src/components/directory/Viewer.vue
@@ -160,8 +160,8 @@
 <script lang="ts" setup>
 import { Ref, computed, nextTick, onMounted, reactive, ref, watch } from "vue";
 
-import { ArrayObjectNamesToStringWithLabel, TextHTMLWithLabel, TextWithLabel } from "vue-library/components";
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
+import { ArrayObjectNamesToStringWithLabel, TextHTMLWithLabel, TextWithLabel } from "@endeavour/vue-library/components";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
 import {
   isConcept,
   isFeature,
@@ -174,8 +174,8 @@ import {
   isQuery,
   isRecordModel,
   isValueSet
-} from "vue-library/helpers";
-import type { ExtendedTTEntity, TTIriRef } from "vue-library/interfaces";
+} from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import ExpressionDisplay from "@/components/directory/viewer/ExpressionDisplay.vue";
 import IndicatorDisplay from "@/components/directory/viewer/IndicatorDisplay.vue";

--- a/src/components/directory/landingPage/Favourites.vue
+++ b/src/components/directory/landingPage/Favourites.vue
@@ -56,13 +56,13 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedSearchResultSummary, TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedSearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { useConfirm } from "primevue/useconfirm";

--- a/src/components/directory/landingPage/RecentActivity.vue
+++ b/src/components/directory/landingPage/RecentActivity.vue
@@ -54,14 +54,14 @@
 <script setup lang="ts">
 import { Ref, computed, onActivated, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isObjectHasKeys } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
-import { RecentActivityItem } from "vue-library/models";
-import { useUserStore } from "vue-library/stores";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
+import { RecentActivityItem } from "@endeavour/vue-library/models";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep, isArray } from "lodash-es";
 import { useConfirm } from "primevue/useconfirm";

--- a/src/components/directory/viewer/Content.vue
+++ b/src/components/directory/viewer/Content.vue
@@ -59,13 +59,13 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, getNamesAsStringFromTypes, isArrayHasLength } from "vue-library/helpers";
-import type { ExtendedEntityReferenceNode, TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, getNamesAsStringFromTypes, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { ExtendedEntityReferenceNode, TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { MenuItem } from "primevue/menuitem";

--- a/src/components/directory/viewer/DataModels.vue
+++ b/src/components/directory/viewer/DataModels.vue
@@ -43,13 +43,13 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { IM, SHACL } from "vue-library/enums";
-import { getColourFromType } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { IM, SHACL } from "@endeavour/vue-library/enums";
+import { getColourFromType } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { DataTableRowSelectEvent } from "primevue/datatable";

--- a/src/components/directory/viewer/Details.vue
+++ b/src/components/directory/viewer/Details.vue
@@ -46,9 +46,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM, SHACL } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { GenericObject } from "vue-library/interfaces";
+import { IM, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { GenericObject } from "@endeavour/vue-library/interfaces";
 
 import { isArray } from "lodash-es";
 import type { TreeNode } from "primevue/treenode";

--- a/src/components/directory/viewer/ExpressionDisplay.vue
+++ b/src/components/directory/viewer/ExpressionDisplay.vue
@@ -19,10 +19,10 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import { EntityService } from "@/services";
 

--- a/src/components/directory/viewer/IMLDisplay.vue
+++ b/src/components/directory/viewer/IMLDisplay.vue
@@ -33,8 +33,8 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import type { IMLLanguage } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import type { IMLLanguage } from "@endeavour/vue-library/interfaces";
 
 interface Props {
   iml: IMLLanguage;

--- a/src/components/directory/viewer/IndicatorDisplay.vue
+++ b/src/components/directory/viewer/IndicatorDisplay.vue
@@ -44,9 +44,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, provide, ref, watch } from "vue";
 
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { Indicator } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Indicator } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 import { useRouter } from "vue-router";

--- a/src/components/directory/viewer/JSONViewer.vue
+++ b/src/components/directory/viewer/JSONViewer.vue
@@ -8,9 +8,9 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { IM } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
 
 import VueJsonPretty from "vue-json-pretty";
 import "vue-json-pretty/lib/styles.css";

--- a/src/components/directory/viewer/Provenance.vue
+++ b/src/components/directory/viewer/Provenance.vue
@@ -72,8 +72,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
 
 import JSONViewer from "@/components/directory/viewer/JSONViewer.vue";
 import { EntityService } from "@/services";

--- a/src/components/directory/viewer/QueryDisplay.vue
+++ b/src/components/directory/viewer/QueryDisplay.vue
@@ -85,9 +85,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, provide, ref, watch } from "vue";
 
-import { Bool, DisplayMode } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { Argument, Node, Query, QueryRequest } from "vue-library/interfaces";
+import { Bool, DisplayMode } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Argument, Node, Query, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/directory/viewer/TermsTable.vue
+++ b/src/components/directory/viewer/TermsTable.vue
@@ -39,7 +39,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { isArrayHasLength } from "vue-library/helpers";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
 
 import { TermCode } from "@/interfaces";
 

--- a/src/components/directory/viewer/UsedIn.vue
+++ b/src/components/directory/viewer/UsedIn.vue
@@ -37,11 +37,11 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { OverlaySummary } from "vue-library/components";
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType } from "vue-library/helpers";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType } from "@endeavour/vue-library/helpers";
 
 import { DataTableRowSelectEvent } from "primevue/datatable";
 

--- a/src/components/directory/viewer/dataModel/DataModel.vue
+++ b/src/components/directory/viewer/dataModel/DataModel.vue
@@ -58,10 +58,10 @@
 <script lang="ts" setup>
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isArrayHasLength } from "vue-library/helpers";
-import type { GenericObject, PropertyRange, PropertyShape, TTIriRef } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { GenericObject, PropertyRange, PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 

--- a/src/components/directory/viewer/dataModel/Properties.vue
+++ b/src/components/directory/viewer/dataModel/Properties.vue
@@ -91,7 +91,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
 
 import { DataTableExpandedRows } from "primevue/datatable";
 

--- a/src/components/directory/viewer/dataModel/TangledTree.vue
+++ b/src/components/directory/viewer/dataModel/TangledTree.vue
@@ -17,8 +17,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, reactive, ref, watch } from "vue";
 
-import { isArrayHasLength } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import * as d3 from "d3";
 import { cloneDeep } from "lodash-es";

--- a/src/components/directory/viewer/graph/Graph.vue
+++ b/src/components/directory/viewer/graph/Graph.vue
@@ -18,9 +18,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { TTBundle } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTBundle } from "@endeavour/vue-library/interfaces";
 
 import { GraphTranslator } from "@/helpers";
 import { TTGraphData } from "@/interfaces";

--- a/src/components/directory/viewer/graph/GraphComponent.vue
+++ b/src/components/directory/viewer/graph/GraphComponent.vue
@@ -21,9 +21,9 @@
 <script lang="ts" setup>
 import { Ref, computed, onMounted, onUnmounted, ref, watch } from "vue";
 
-import { IM, ToastSeverity } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import { ToastOptions } from "vue-library/models";
+import { IM, ToastSeverity } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import { ToastOptions } from "@endeavour/vue-library/models";
 
 import * as d3 from "d3";
 import { cloneDeep } from "lodash-es";

--- a/src/components/directory/viewer/mapping/Mappings.vue
+++ b/src/components/directory/viewer/mapping/Mappings.vue
@@ -124,9 +124,9 @@
 <script lang="ts" setup>
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import { byPriority, byScheme, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ConceptContextMap, GenericObject, Namespace } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import { byPriority, byScheme, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ConceptContextMap, GenericObject, Namespace } from "@endeavour/vue-library/interfaces";
 
 import { ChartMapNode, ChartTableNode, MapItem, SimpleMap, SimpleMapIri } from "@/interfaces";
 import { Context } from "@/interfaces/Context";

--- a/src/components/directory/viewer/set/CompareSetDialog.vue
+++ b/src/components/directory/viewer/set/CompareSetDialog.vue
@@ -33,7 +33,7 @@
 <script setup lang="ts">
 import { Ref, ref, watch } from "vue";
 
-import type { Concept, SearchResultSummary } from "vue-library/interfaces";
+import type { Concept, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import { SetService } from "@/services";
 

--- a/src/components/directory/viewer/set/CompareSetSection.vue
+++ b/src/components/directory/viewer/set/CompareSetSection.vue
@@ -34,12 +34,12 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 
-import { OverlaySummary } from "vue-library/components";
-import { useCopyToClipboard } from "vue-library/composables";
-import { useOverlay } from "vue-library/composables";
-import { IM, NAMESPACE } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Concept, FilterOptions, QueryRequest, SearchResultSummary } from "vue-library/interfaces";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { IM, NAMESPACE } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Concept, FilterOptions, QueryRequest, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import AutocompleteSearchBar from "@/components/shared/AutocompleteSearchBar.vue";
 import { useDirectService } from "@/composables/useDirectService";

--- a/src/components/directory/viewer/set/EclDefinition.vue
+++ b/src/components/directory/viewer/set/EclDefinition.vue
@@ -18,7 +18,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
 
 import { EclService } from "@/services";
 

--- a/src/components/directory/viewer/set/Members.vue
+++ b/src/components/directory/viewer/set/Members.vue
@@ -42,9 +42,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { Node, Query } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Node, Query } from "@endeavour/vue-library/interfaces";
 
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";
 import { EntityService, SetService } from "@/services";

--- a/src/components/directory/viewer/set/MembersPreview.vue
+++ b/src/components/directory/viewer/set/MembersPreview.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ECLQueryRequest, Query } from "vue-library/interfaces";
+import type { ECLQueryRequest, Query } from "@endeavour/vue-library/interfaces";
 
 import Members from "@/components/directory/viewer/set/Members.vue";
 

--- a/src/components/directory/viewer/set/SetDefinition.vue
+++ b/src/components/directory/viewer/set/SetDefinition.vue
@@ -93,15 +93,15 @@
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, markRaw, onMounted, ref, watch } from "vue";
 
-import { ArrayObjectNamesToStringWithLabel } from "vue-library/components";
-import { useDownloadFile } from "vue-library/composables";
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM, RDFS } from "vue-library/enums";
-import { ToastSeverity, UserRole } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, SetExportRequest, SetOptions } from "vue-library/interfaces";
-import { ToastOptions } from "vue-library/models";
-import { useUserStore } from "vue-library/stores";
+import { ArrayObjectNamesToStringWithLabel } from "@endeavour/vue-library/components";
+import { useDownloadFile } from "@endeavour/vue-library/composables";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { ToastSeverity, UserRole } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, SetExportRequest, SetOptions } from "@endeavour/vue-library/interfaces";
+import { ToastOptions } from "@endeavour/vue-library/models";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useDialog } from "primevue/usedialog";
 import { useToast } from "primevue/usetoast";

--- a/src/components/directory/viewer/set/SubsetDisplay.vue
+++ b/src/components/directory/viewer/set/SubsetDisplay.vue
@@ -24,7 +24,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";
 import { SetService } from "@/services";

--- a/src/components/editor/SideBar.vue
+++ b/src/components/editor/SideBar.vue
@@ -7,9 +7,9 @@
 <script lang="ts" setup>
 import { onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import VueJsonPretty from "vue-json-pretty";

--- a/src/components/editor/shapeComponents/ArrayBuilder.vue
+++ b/src/components/editor/shapeComponents/ArrayBuilder.vue
@@ -46,9 +46,9 @@ export default defineComponent({
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { SHACL } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/AutocompleteSearchBarWrapper.vue
+++ b/src/components/editor/shapeComponents/AutocompleteSearchBarWrapper.vue
@@ -22,10 +22,10 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS, ToastSeverity } from "vue-library/enums";
-import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { SearchResultSummary, TTIriRef } from "vue-library/interfaces";
-import type { GenericObject, PropertyShape, QueryRequest } from "vue-library/interfaces";
+import { RDFS, ToastSeverity } from "@endeavour/vue-library/enums";
+import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
+import type { GenericObject, PropertyShape, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 import { useToast } from "primevue/usetoast";

--- a/src/components/editor/shapeComponents/BuilderChildWrapper.vue
+++ b/src/components/editor/shapeComponents/BuilderChildWrapper.vue
@@ -51,7 +51,7 @@ export default defineComponent({
 </script>
 
 <script setup lang="ts">
-import type { PropertyShape } from "vue-library/interfaces";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import AddDeleteButtons from "@/components/editor/shapeComponents/AddDeleteButtons.vue";
 import UpDownButtons from "@/components/editor/shapeComponents/UpDownButtons.vue";

--- a/src/components/editor/shapeComponents/CheckboxDisplay.vue
+++ b/src/components/editor/shapeComponents/CheckboxDisplay.vue
@@ -11,8 +11,8 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import type { PropertyShape, TTIriRef } from "vue-library/interfaces";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import type { PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/ComponentGroup.vue
+++ b/src/components/editor/shapeComponents/ComponentGroup.vue
@@ -30,8 +30,8 @@ export default defineComponent({
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { TypeGuards, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { TypeGuards, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { EditorMode } from "@/enums";
 import { processComponentType } from "@/helpers/EditorMethods";

--- a/src/components/editor/shapeComponents/DropdownTextInputConcatenator.vue
+++ b/src/components/editor/shapeComponents/DropdownTextInputConcatenator.vue
@@ -19,9 +19,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { TypeGuards, byName, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, Query, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { TypeGuards, byName, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, Query, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/EntityAutoComplete.vue
+++ b/src/components/editor/shapeComponents/EntityAutoComplete.vue
@@ -71,9 +71,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import { IM, QUERY, RDF, RDFS } from "vue-library/enums";
-import { TypeGuards, byName, getNamesAsStringFromTypes, isArrayHasLength, isObject, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, SearchResultSummary, TTIriRef } from "vue-library/interfaces";
+import { IM, QUERY, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { TypeGuards, byName, getNamesAsStringFromTypes, isArrayHasLength, isObject, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { AbortController } from "abortcontroller-polyfill/dist/cjs-ponyfill";
 import { cloneDeep, isEqual } from "lodash-es";

--- a/src/components/editor/shapeComponents/EntityComboBox.vue
+++ b/src/components/editor/shapeComponents/EntityComboBox.vue
@@ -27,9 +27,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { byName, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, Query, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { byName, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, Query, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/EntityDisplay.vue
+++ b/src/components/editor/shapeComponents/EntityDisplay.vue
@@ -13,9 +13,9 @@
 <script setup lang="ts">
 import { Ref, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/EntityDropdown.vue
+++ b/src/components/editor/shapeComponents/EntityDropdown.vue
@@ -22,9 +22,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { TypeGuards, byName, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { TypeGuards, byName, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/EntitySearch.vue
+++ b/src/components/editor/shapeComponents/EntitySearch.vue
@@ -26,10 +26,10 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS, ToastSeverity } from "vue-library/enums";
-import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { SearchResultSummary, TTIriRef } from "vue-library/interfaces";
-import type { ExtendedTTEntity, PropertyShape, QueryRequest } from "vue-library/interfaces";
+import { RDFS, ToastSeverity } from "@endeavour/vue-library/enums";
+import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
+import type { ExtendedTTEntity, PropertyShape, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 import { useToast } from "primevue/usetoast";

--- a/src/components/editor/shapeComponents/HorizontalLayout.vue
+++ b/src/components/editor/shapeComponents/HorizontalLayout.vue
@@ -22,8 +22,8 @@ export default defineComponent({
 <script setup lang="ts">
 import { Ref, inject, onMounted, ref } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { EditorMode } from "@/enums";
 import { processComponentType } from "@/helpers/EditorMethods";

--- a/src/components/editor/shapeComponents/HtmlInput.vue
+++ b/src/components/editor/shapeComponents/HtmlInput.vue
@@ -19,7 +19,7 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import type { ExtendedTTEntity, PropertyShape } from "vue-library/interfaces";
+import type { ExtendedTTEntity, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/IndicatorDefinition.vue
+++ b/src/components/editor/shapeComponents/IndicatorDefinition.vue
@@ -40,10 +40,10 @@
 <script lang="ts" setup>
 import { Ref, inject, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { DisplayMode } from "vue-library/enums";
-import { IM } from "vue-library/enums";
-import type { PropertyShape, Query, QueryRequest } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { DisplayMode } from "@endeavour/vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
+import type { PropertyShape, Query, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/IriBuilder.vue
+++ b/src/components/editor/shapeComponents/IriBuilder.vue
@@ -34,9 +34,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, NAMESPACE, RDFS } from "vue-library/enums";
-import { TypeGuards, byName, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { IM, NAMESPACE, RDFS } from "@endeavour/vue-library/enums";
+import { TypeGuards, byName, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/PropertyBuilder.vue
+++ b/src/components/editor/shapeComponents/PropertyBuilder.vue
@@ -161,10 +161,10 @@
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { IM, NAMESPACE, RDF, RDFS, SHACL, SNOMED, XSD } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, QueryRequest, SearchResultSummary, TTIriRef } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { IM, NAMESPACE, RDF, RDFS, SHACL, SNOMED, XSD } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, QueryRequest, SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/QueryDefinitionBuilder.vue
+++ b/src/components/editor/shapeComponents/QueryDefinitionBuilder.vue
@@ -39,17 +39,17 @@
 <script lang="ts" setup>
 import { Ref, inject, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { DisplayMode } from "vue-library/enums";
-import { IM } from "vue-library/enums";
-import type { PropertyShape, Query, QueryRequest } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { DisplayMode } from "@endeavour/vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
+import type { PropertyShape, Query, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 
 import QueryDisplay from "@/components/directory/viewer/QueryDisplay.vue";
 import SQLDisplay from "@/components/directory/viewer/SQLDisplay.vue";
-import TestQueryResults from "@/components/query/viewer/TestQueryResults.vue";
 import QueryEditor from "@/components/imquery/QueryEditor.vue";
+import TestQueryResults from "@/components/query/viewer/TestQueryResults.vue";
 import { EditorMode } from "@/enums";
 import injectionKeys from "@/injectionKeys/injectionKeys";
 import { EntityService, QueryService } from "@/services";

--- a/src/components/editor/shapeComponents/RoleGroupBuilder.vue
+++ b/src/components/editor/shapeComponents/RoleGroupBuilder.vue
@@ -43,9 +43,9 @@
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, NAMESPACE, RDFS, SNOMED } from "vue-library/enums";
-import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, QueryRequest } from "vue-library/interfaces";
+import { IM, NAMESPACE, RDFS, SNOMED } from "@endeavour/vue-library/enums";
+import { TypeGuards, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isArray } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/SetDefinitionBuilder.vue
+++ b/src/components/editor/shapeComponents/SetDefinitionBuilder.vue
@@ -81,10 +81,10 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, nextTick, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ECLQueryRequest, ExtendedTTEntity, PropertyShape, SearchResultSummary } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { IM } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ECLQueryRequest, ExtendedTTEntity, PropertyShape, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual, last } from "lodash-es";
 import { useDialog } from "primevue/usedialog";

--- a/src/components/editor/shapeComponents/TabLayout.vue
+++ b/src/components/editor/shapeComponents/TabLayout.vue
@@ -28,8 +28,8 @@ export default defineComponent({
 <script setup lang="ts">
 import { Ref, inject, onMounted, ref } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { MenuItem } from "primevue/menuitem";
 import TabPanel from "primevue/tabpanel";

--- a/src/components/editor/shapeComponents/TermCodeEditor.vue
+++ b/src/components/editor/shapeComponents/TermCodeEditor.vue
@@ -22,9 +22,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, TTIriRef } from "vue-library/interfaces";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/TextDisplay.vue
+++ b/src/components/editor/shapeComponents/TextDisplay.vue
@@ -21,8 +21,8 @@
 <script setup lang="ts">
 import { Ref, inject, onMounted, ref, watch } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { Argument, ExtendedTTEntity, PropertyShape } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Argument, ExtendedTTEntity, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/TextDropdown.vue
+++ b/src/components/editor/shapeComponents/TextDropdown.vue
@@ -15,9 +15,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, Query, QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/TextInput.vue
+++ b/src/components/editor/shapeComponents/TextInput.vue
@@ -21,7 +21,7 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import type { ExtendedTTEntity, PropertyShape } from "vue-library/interfaces";
+import type { ExtendedTTEntity, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/editor/shapeComponents/ToggleableComponent.vue
+++ b/src/components/editor/shapeComponents/ToggleableComponent.vue
@@ -34,8 +34,8 @@ export default defineComponent({
 <script setup lang="ts">
 import { inject, onMounted, ref, watch } from "vue";
 
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, TTIriRef } from "vue-library/interfaces";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { EditorMode } from "@/enums";
 import { processComponentType } from "@/helpers/EditorMethods";

--- a/src/components/editor/shapeComponents/VerticalLayout.vue
+++ b/src/components/editor/shapeComponents/VerticalLayout.vue
@@ -60,8 +60,8 @@ export default defineComponent({
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { EditorMode } from "@/enums";
 import { processComponentType } from "@/helpers/EditorMethods";

--- a/src/components/editor/shapeComponents/builder/AddNext.vue
+++ b/src/components/editor/shapeComponents/builder/AddNext.vue
@@ -10,8 +10,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { stringAscending } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { stringAscending } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { ComponentType, EditorMode } from "@/enums";
 import { ComponentDetails, NextComponentSummary } from "@/interfaces";

--- a/src/components/editor/shapeComponents/builder/quantifier/QuantifierTree.vue
+++ b/src/components/editor/shapeComponents/builder/quantifier/QuantifierTree.vue
@@ -26,9 +26,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { byKey, getColourFromType, getFAIconFromType, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { EntityReferenceNode, GenericObject, TTIriRef } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { byKey, getColourFromType, getFAIconFromType, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { EntityReferenceNode, GenericObject, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 import { useToast } from "primevue/usetoast";

--- a/src/components/editor/shapeComponents/setDefinition/AddByCodeList.vue
+++ b/src/components/editor/shapeComponents/setDefinition/AddByCodeList.vue
@@ -62,7 +62,7 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, ref } from "vue";
 
-import { isArrayHasLength } from "vue-library/helpers";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
 
 import * as d3 from "d3";
 import { DSVRowArray } from "d3";

--- a/src/components/editor/shapeComponents/setDefinition/SubsetBuilder.vue
+++ b/src/components/editor/shapeComponents/setDefinition/SubsetBuilder.vue
@@ -13,9 +13,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, QUERY, RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, PropertyShape, TTIriRef } from "vue-library/interfaces";
+import { IM, QUERY, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 

--- a/src/components/imquery/BaseTypeEditor.vue
+++ b/src/components/imquery/BaseTypeEditor.vue
@@ -35,8 +35,8 @@
 <script lang="ts" setup>
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM, NAMESPACE, RDF, RDFS, SHACL } from "vue-library/enums";
-import type { Match, QueryRequest, SearchResultSummary } from "vue-library/interfaces";
+import { IM, NAMESPACE, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import type { Match, QueryRequest, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 

--- a/src/components/imquery/BaseTypeSelector.vue
+++ b/src/components/imquery/BaseTypeSelector.vue
@@ -11,7 +11,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 
-import type { Query, QueryRequest, SearchResultSummary } from "vue-library/interfaces";
+import type { Query, QueryRequest, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import DirectorySearchDialog from "@/components/shared/dialogs/DirectorySearchDialog.vue";
 

--- a/src/components/imquery/BooleanEditor.vue
+++ b/src/components/imquery/BooleanEditor.vue
@@ -58,8 +58,8 @@
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 import { defineComponent } from "vue";
 
-import { Bool } from "vue-library/enums";
-import type { Match, Where } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match, Where } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 

--- a/src/components/imquery/BooleanMatchEditor.vue
+++ b/src/components/imquery/BooleanMatchEditor.vue
@@ -126,8 +126,8 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref } from "vue";
 
-import { Bool } from "vue-library/enums";
-import type { Match, Node } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match, Node } from "@endeavour/vue-library/interfaces";
 
 import { isEqual } from "lodash-es";
 import Button from "primevue/button";

--- a/src/components/imquery/BooleanWhereEditor.vue
+++ b/src/components/imquery/BooleanWhereEditor.vue
@@ -89,8 +89,8 @@
 <script lang="ts" setup>
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { Bool } from "vue-library/enums";
-import type { Match, Node, UIProperty, Where } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match, Node, UIProperty, Where } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import Button from "primevue/button";

--- a/src/components/imquery/CohortEditor.vue
+++ b/src/components/imquery/CohortEditor.vue
@@ -107,8 +107,8 @@
 <script lang="ts" setup>
 import { Ref, computed, onMounted, provide, ref, watch } from "vue";
 
-import { Bool, IM, NAMESPACE } from "vue-library/enums";
-import type { Match, Node, NodeShape, QueryRequest, SearchResponse, SearchResultSummary, TTIriRef } from "vue-library/interfaces";
+import { Bool, IM, NAMESPACE } from "@endeavour/vue-library/enums";
+import type { Match, Node, NodeShape, QueryRequest, SearchResponse, SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 import ProgressSpinner from "primevue/progressspinner";

--- a/src/components/imquery/ColumnGroupEditor.vue
+++ b/src/components/imquery/ColumnGroupEditor.vue
@@ -72,10 +72,10 @@
 <script lang="ts" setup>
 import { Ref, computed, onMounted, ref } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { DisplayMode } from "vue-library/enums";
-import { IM } from "vue-library/enums";
-import type { Match, Node, Return } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { DisplayMode } from "@endeavour/vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
+import type { Match, Node, Return } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 import type { TreeNode } from "primevue/treenode";

--- a/src/components/imquery/ConceptSelector.vue
+++ b/src/components/imquery/ConceptSelector.vue
@@ -47,8 +47,8 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import type { Node, QueryRequest, SearchResultSummary } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import type { Node, QueryRequest, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, isEqual } from "lodash-es";
 

--- a/src/components/imquery/DataSetEditor.vue
+++ b/src/components/imquery/DataSetEditor.vue
@@ -29,7 +29,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import type { Match, Node, Query } from "vue-library/interfaces";
+import type { Match, Node, Query } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 import { v4 } from "uuid";

--- a/src/components/imquery/ECLBuilder.vue
+++ b/src/components/imquery/ECLBuilder.vue
@@ -69,9 +69,9 @@
 <script setup lang="ts">
 import { Ref, nextTick, onMounted, provide, readonly, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { ECLQueryRequest, Match, Node, Query } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ECLQueryRequest, Match, Node, Query } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import { useDialog } from "primevue/usedialog";

--- a/src/components/imquery/ECLExpressionConstraint.vue
+++ b/src/components/imquery/ECLExpressionConstraint.vue
@@ -156,9 +156,9 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { Bool } from "vue-library/enums";
-import { QUERY } from "vue-library/enums";
-import type { Match, Node, QueryRequest, TTIriRef, Where } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import { QUERY } from "@endeavour/vue-library/enums";
+import type { Match, Node, QueryRequest, TTIriRef, Where } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 import { v4 } from "uuid";

--- a/src/components/imquery/ECLRefinement.vue
+++ b/src/components/imquery/ECLRefinement.vue
@@ -129,9 +129,9 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, QUERY } from "vue-library/enums";
-import { Bool } from "vue-library/enums";
-import type { Match, QueryRequest, SearchResultSummary, Where } from "vue-library/interfaces";
+import { IM, QUERY } from "@endeavour/vue-library/enums";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match, QueryRequest, SearchResultSummary, Where } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 import { useToast } from "primevue/usetoast";

--- a/src/components/imquery/ECLRefinementValue.vue
+++ b/src/components/imquery/ECLRefinementValue.vue
@@ -61,8 +61,8 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { IM, QUERY, SNOMED, ToastSeverity } from "vue-library/enums";
-import type { Node, QueryRequest, SearchResultSummary, TTIriRef, Where } from "vue-library/interfaces";
+import { IM, QUERY, SNOMED, ToastSeverity } from "@endeavour/vue-library/enums";
+import type { Node, QueryRequest, SearchResultSummary, TTIriRef, Where } from "@endeavour/vue-library/interfaces";
 
 import { isEqual } from "lodash-es";
 import Button from "primevue/button";

--- a/src/components/imquery/EntailmentOptionsSelect.vue
+++ b/src/components/imquery/EntailmentOptionsSelect.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import type { Entailment } from "vue-library/interfaces";
+import type { Entailment } from "@endeavour/vue-library/interfaces";
 
 const props = defineProps<{
   entailmentObject: Entailment;

--- a/src/components/imquery/FieldEditor.vue
+++ b/src/components/imquery/FieldEditor.vue
@@ -28,9 +28,9 @@
 </template>
 
 <script setup lang="ts">
-import { Bool } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Return } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Return } from "@endeavour/vue-library/interfaces";
 
 import FunctionClauseDisplay from "@/components/query/viewer/FunctionClauseDisplay.vue";
 import RecursiveWhereDisplay from "@/components/query/viewer/RecursiveWhereDisplay.vue";

--- a/src/components/imquery/FieldSelector.vue
+++ b/src/components/imquery/FieldSelector.vue
@@ -32,7 +32,7 @@
 <script lang="ts" setup>
 import { onMounted, ref, watch } from "vue";
 
-import type { Node } from "vue-library/interfaces";
+import type { Node } from "@endeavour/vue-library/interfaces";
 
 import { TreeSelectionKeys } from "primevue/tree";
 import type { TreeNode } from "primevue/treenode";

--- a/src/components/imquery/MatchContentDisplay.vue
+++ b/src/components/imquery/MatchContentDisplay.vue
@@ -63,8 +63,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { Bool } from "vue-library/enums";
-import type { Match } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match } from "@endeavour/vue-library/interfaces";
 
 import WhereContentDisplay from "@/components/imquery/WhereContentDisplay.vue";
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";

--- a/src/components/imquery/MatchContentEditor.vue
+++ b/src/components/imquery/MatchContentEditor.vue
@@ -102,7 +102,7 @@
       </span>
       <Button data-testid="add-test-button" class="add-button" label="Add related feature" @click="addLinked" />
     </div>
-    <div v-if="(match.where || match.orderBy) &&parentOperator && parentOperator===Bool.or">
+    <div v-if="(match.where || match.orderBy) && parentOperator && parentOperator === Bool.or">
       <span class="description">Optionally assign score if true</span>
       <InputText v-model="match.score" type="text" class="match-score" @update:model-value="updateScore" />
     </div>
@@ -112,19 +112,19 @@
 <script lang="ts" setup>
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import { IM } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Match, Node, NodeShape, TTIriRef} from "vue-library/interfaces";
-import {Bool} from "vue-library/enums";
-import { cloneDeep, isEqual } from "lodash-es";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { Bool, IM } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Match, Node, NodeShape, TTIriRef } from "@endeavour/vue-library/interfaces";
+
+import { cloneDeep } from "lodash-es";
 import Button from "primevue/button";
 
 import BooleanWhereEditor from "@/components/imquery/BooleanWhereEditor.vue";
 import MatchContentDisplay from "@/components/imquery/MatchContentDisplay.vue";
 import WhereContentDisplay from "@/components/imquery/WhereContentDisplay.vue";
 import { getOrderOptions, getOrderable } from "@/helpers/QueryEditorMethods";
-import { createNodeVariable, getBooleanOperator, getOrderables } from "@/helpers/buildQuery";
+import { getBooleanOperator, getOrderables } from "@/helpers/buildQuery";
 import { EntityService } from "@/services";
 
 interface Props {
@@ -134,7 +134,7 @@ interface Props {
   isStep?: boolean;
   nodeShape: NodeShape;
   editingThen?: boolean;
-  parentOperator? : Bool
+  parentOperator?: Bool;
 }
 
 const props = defineProps<Props>();
@@ -319,7 +319,6 @@ function onDeleteThen() {
 .keep-as-reference {
   padding-right: 1rem;
 }
-
 
 .match-score {
   width: 20rem;

--- a/src/components/imquery/MatchEditor.vue
+++ b/src/components/imquery/MatchEditor.vue
@@ -158,19 +158,26 @@
     </Dialog>
   </div>
   <div v-if="editMatch.is">
-    <CohortEditor v-model:match="editMatch"  :parentOperator="parentOperator" :editMode="editCohort" @updateCohort="onSave" @updateClauses="onUpdateClauses" @cancel="cancel" />
+    <CohortEditor
+      v-model:match="editMatch"
+      :parentOperator="parentOperator"
+      :editMode="editCohort"
+      @updateCohort="onSave"
+      @updateClauses="onUpdateClauses"
+      @cancel="cancel"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { Ref, inject, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { useCopyToClipboard } from "vue-library/composables";
-import { Bool, DisplayMode } from "vue-library/enums";
-import { IM } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Match, Node, NodeShape, Return, TTIriRef } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import { Bool, DisplayMode } from "@endeavour/vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Match, Node, NodeShape, Return, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import type { TreeNode } from "primevue/treenode";

--- a/src/components/imquery/ParameterSelect.vue
+++ b/src/components/imquery/ParameterSelect.vue
@@ -15,9 +15,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IM, QUERY, RDFS, SHACL } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { IM, QUERY, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { EntityService, QueryService } from "@/services";
 

--- a/src/components/imquery/QueryEditor.vue
+++ b/src/components/imquery/QueryEditor.vue
@@ -68,8 +68,8 @@
 <script setup lang="ts">
 import { Ref, nextTick, onMounted, provide, readonly, ref, watch } from "vue";
 
-import { useCopyToClipboard } from "vue-library/composables";
-import type { Match, Query } from "vue-library/interfaces";
+import { useCopyToClipboard } from "@endeavour/vue-library/composables";
+import type { Match, Query } from "@endeavour/vue-library/interfaces";
 
 import { value } from "jsonpath";
 import { cloneDeep, isEqual } from "lodash-es";

--- a/src/components/imquery/RelativeToSelect.vue
+++ b/src/components/imquery/RelativeToSelect.vue
@@ -37,7 +37,7 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref, watch } from "vue";
 
-import type { Match, Query, UIProperty, Where } from "vue-library/interfaces";
+import type { Match, Query, UIProperty, Where } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 

--- a/src/components/imquery/ReturnEditor.vue
+++ b/src/components/imquery/ReturnEditor.vue
@@ -50,9 +50,9 @@
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
 
-import { Bool } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Match, Return } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Match, Return } from "@endeavour/vue-library/interfaces";
 
 import FunctionClauseDisplay from "@/components/query/viewer/FunctionClauseDisplay.vue";
 import RecursiveWhereDisplay from "@/components/query/viewer/RecursiveWhereDisplay.vue";

--- a/src/components/imquery/RoleGroup.vue
+++ b/src/components/imquery/RoleGroup.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 
-import type { Where } from "vue-library/interfaces";
+import type { Where } from "@endeavour/vue-library/interfaces";
 
 import { getIsRoleGroup, isBoolWhere, manageRoleGroup } from "@/helpers/buildQuery";
 

--- a/src/components/imquery/RuleActionEditor.vue
+++ b/src/components/imquery/RuleActionEditor.vue
@@ -21,7 +21,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import type { Match } from "vue-library/interfaces";
+import type { Match } from "@endeavour/vue-library/interfaces";
 
 import { getRuleAction, getRuleActionLabel, getRuleActionOptions, setRuleAction } from "@/helpers/buildQuery";
 

--- a/src/components/imquery/SaveCustomSetDialog.vue
+++ b/src/components/imquery/SaveCustomSetDialog.vue
@@ -63,9 +63,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM, IM_FUNCTION, NAMESPACE, RDF, RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { Match, Node, TTIriRef } from "vue-library/interfaces";
+import { IM, IM_FUNCTION, NAMESPACE, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Match, Node, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { useToast } from "primevue/usetoast";
 import { useForm } from "vee-validate";

--- a/src/components/imquery/SelectedSet.vue
+++ b/src/components/imquery/SelectedSet.vue
@@ -35,12 +35,12 @@
 <script lang="ts" setup>
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isArrayHasLength, isConcept, isValueSet } from "vue-library/helpers";
-import type { ExtendedTTEntity, Match, Node, TTIriRef } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isArrayHasLength, isConcept, isValueSet } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, Match, Node, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/imquery/TypeSelector.vue
+++ b/src/components/imquery/TypeSelector.vue
@@ -37,8 +37,8 @@
 <script lang="ts" setup>
 import { Ref, nextTick, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import type { Match, Node, Path } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import type { Match, Node, Path } from "@endeavour/vue-library/interfaces";
 
 import { TreeSelectionKeys } from "primevue/tree";
 import type { TreeNode } from "primevue/treenode";

--- a/src/components/imquery/ValueEditor.vue
+++ b/src/components/imquery/ValueEditor.vue
@@ -61,9 +61,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { Operator } from "vue-library/enums";
-import { IM, XSD } from "vue-library/enums";
-import type { Assignable, Match, TTIriRef, UIProperty, Where } from "vue-library/interfaces";
+import { Operator } from "@endeavour/vue-library/enums";
+import { IM, XSD } from "@endeavour/vue-library/enums";
+import type { Assignable, Match, TTIriRef, UIProperty, Where } from "@endeavour/vue-library/interfaces";
 
 import RelativeToSelect from "@/components/imquery/RelativeToSelect.vue";
 import { CompareOptions } from "@/constants";

--- a/src/components/imquery/WhereContentDisplay.vue
+++ b/src/components/imquery/WhereContentDisplay.vue
@@ -51,9 +51,9 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
-import { Bool, IM } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isArrayHasLength } from "vue-library/helpers";
-import type { Node, Where } from "vue-library/interfaces";
+import { Bool, IM } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Node, Where } from "@endeavour/vue-library/interfaces";
 
 import ValueSentenceDisplay from "@/components/imquery/ValueSentenceDisplay.vue";
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";

--- a/src/components/imquery/WhereIsEditor.vue
+++ b/src/components/imquery/WhereIsEditor.vue
@@ -97,9 +97,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import { getIconColor, getTypeIcon } from "vue-library/helpers";
-import type { Node, QueryRequest, SearchResultSummary, UIProperty, Where } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import { getIconColor, getTypeIcon } from "@endeavour/vue-library/helpers";
+import type { Node, QueryRequest, SearchResultSummary, UIProperty, Where } from "@endeavour/vue-library/interfaces";
 
 import Button from "primevue/button";
 

--- a/src/components/imquery/WhereValueEditor.vue
+++ b/src/components/imquery/WhereValueEditor.vue
@@ -86,9 +86,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM, XSD } from "vue-library/enums";
-import { Operator } from "vue-library/enums";
-import type { Assignable, Match, UIProperty, Where } from "vue-library/interfaces";
+import { IM, XSD } from "@endeavour/vue-library/enums";
+import { Operator } from "@endeavour/vue-library/enums";
+import type { Assignable, Match, UIProperty, Where } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/imquery/functionTemplates/FunctionComponent.vue
+++ b/src/components/imquery/functionTemplates/FunctionComponent.vue
@@ -15,9 +15,9 @@
 </template>
 
 <script setup lang="ts">
-import { Order } from "vue-library/enums";
-import { IM, RDFS, SHACL } from "vue-library/enums";
-import type { OrderLimit } from "vue-library/interfaces";
+import { Order } from "@endeavour/vue-library/enums";
+import { IM, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import type { OrderLimit } from "@endeavour/vue-library/interfaces";
 
 defineProps<{
   functionTemplates: any;

--- a/src/components/query/viewer/BooleanMatchDisplay.vue
+++ b/src/components/query/viewer/BooleanMatchDisplay.vue
@@ -20,7 +20,7 @@
       />
       <span class="clause-label">Check to add to import list</span>
     </span>
-    <ValueSentenceDisplay v-if="match.having &&havingSentence" :value-sentence="havingSentence" />
+    <ValueSentenceDisplay v-if="match.having && havingSentence" :value-sentence="havingSentence" />
     <template v-for="(nestedQuery, index) in boolGroup" :key="`nestedQueryDisplay-${index}`">
       <RecursiveMatchDisplay
         :match="nestedQuery"
@@ -46,8 +46,8 @@
 <script setup lang="ts">
 import { Ref, computed, inject, ref } from "vue";
 
-import { Bool } from "vue-library/enums";
-import type { Match, Node } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import type { Match, Node } from "@endeavour/vue-library/interfaces";
 
 import ValueSentenceDisplay from "@/components/imquery/ValueSentenceDisplay.vue";
 import RecursiveMatchDisplay from "@/components/query/viewer/RecursiveMatchDisplay.vue";

--- a/src/components/query/viewer/ColumnGroupDisplay.vue
+++ b/src/components/query/viewer/ColumnGroupDisplay.vue
@@ -31,8 +31,8 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 
-import { Bool, DisplayMode } from "vue-library/enums";
-import type { Match, Node, Query } from "vue-library/interfaces";
+import { Bool, DisplayMode } from "@endeavour/vue-library/enums";
+import type { Match, Node, Query } from "@endeavour/vue-library/interfaces";
 
 import { QueryService } from "@/services";
 

--- a/src/components/query/viewer/FunctionClauseDisplay.vue
+++ b/src/components/query/viewer/FunctionClauseDisplay.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import type { FunctionClause, Node } from "vue-library/interfaces";
+import type { FunctionClause, Node } from "@endeavour/vue-library/interfaces";
 
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";
 

--- a/src/components/query/viewer/ListOverlay.vue
+++ b/src/components/query/viewer/ListOverlay.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Node } from "vue-library/interfaces";
+import type { Node } from "@endeavour/vue-library/interfaces";
 
 defineProps<{
   list: Node[];

--- a/src/components/query/viewer/MatchDescription.vue
+++ b/src/components/query/viewer/MatchDescription.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Match } from "vue-library/interfaces";
+import type { Match } from "@endeavour/vue-library/interfaces";
 
 interface Props {
   match: Match;

--- a/src/components/query/viewer/RecursiveMatchDisplay.vue
+++ b/src/components/query/viewer/RecursiveMatchDisplay.vue
@@ -124,8 +124,8 @@
 <script setup lang="ts">
 import { Ref, computed, inject, ref } from "vue";
 
-import { Bool, DisplayMode } from "vue-library/enums";
-import type { Match, Node } from "vue-library/interfaces";
+import { Bool, DisplayMode } from "@endeavour/vue-library/enums";
+import type { Match, Node } from "@endeavour/vue-library/interfaces";
 
 import BooleanMatchDisplay from "@/components/query/viewer/BooleanMatchDisplay.vue";
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";

--- a/src/components/query/viewer/RecursiveReturnDisplay.vue
+++ b/src/components/query/viewer/RecursiveReturnDisplay.vue
@@ -33,9 +33,9 @@
 </template>
 
 <script setup lang="ts">
-import { Bool } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Return } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Return } from "@endeavour/vue-library/interfaces";
 
 import FunctionClauseDisplay from "@/components/query/viewer/FunctionClauseDisplay.vue";
 import RecursiveWhereDisplay from "@/components/query/viewer/RecursiveWhereDisplay.vue";

--- a/src/components/query/viewer/RecursiveWhereDisplay.vue
+++ b/src/components/query/viewer/RecursiveWhereDisplay.vue
@@ -54,9 +54,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref } from "vue";
 
-import { Bool } from "vue-library/enums";
-import { getIconColor, getTypeIcon, isArrayHasLength } from "vue-library/helpers";
-import type { Node, Where } from "vue-library/interfaces";
+import { Bool } from "@endeavour/vue-library/enums";
+import { getIconColor, getTypeIcon, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Node, Where } from "@endeavour/vue-library/interfaces";
 
 import ValueSentenceDisplay from "@/components/imquery/ValueSentenceDisplay.vue";
 import IMViewerLink from "@/components/shared/IMViewerLink.vue";

--- a/src/components/query/viewer/ReturnColumns.vue
+++ b/src/components/query/viewer/ReturnColumns.vue
@@ -10,8 +10,8 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Query, Return } from "vue-library/interfaces";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Query, Return } from "@endeavour/vue-library/interfaces";
 
 import RecursiveReturnDisplay from "./RecursiveReturnDisplay.vue";
 

--- a/src/components/query/viewer/TestQueryResults.vue
+++ b/src/components/query/viewer/TestQueryResults.vue
@@ -26,7 +26,7 @@
 <script setup lang="ts">
 import { Ref, ref } from "vue";
 
-import type { DBEntry } from "vue-library/interfaces";
+import type { DBEntry } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/shared/ActionButtons.vue
+++ b/src/components/shared/ActionButtons.vue
@@ -89,9 +89,9 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 
-import { useDownloadFile } from "vue-library/composables";
-import { isArrayHasLength } from "vue-library/helpers";
-import { useUserStore } from "vue-library/stores";
+import { useDownloadFile } from "@endeavour/vue-library/composables";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 import { useDialog } from "primevue/usedialog";

--- a/src/components/shared/AutocompleteSearchBar.vue
+++ b/src/components/shared/AutocompleteSearchBar.vue
@@ -79,13 +79,13 @@
 <script setup lang="ts">
 import { Ref, computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import { OverlaySummary } from "vue-library/components";
-import { useSpeechToText } from "vue-library/composables";
-import { useOverlay } from "vue-library/composables";
-import { TextSearchStyle } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { FilterOptions } from "vue-library/interfaces";
-import type { QueryRequest, SearchResponse, SearchResultSummary } from "vue-library/interfaces";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useSpeechToText } from "@endeavour/vue-library/composables";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { TextSearchStyle } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { FilterOptions } from "@endeavour/vue-library/interfaces";
+import type { QueryRequest, SearchResponse, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep, debounce, isEqual } from "lodash-es";
 

--- a/src/components/shared/Filters.vue
+++ b/src/components/shared/Filters.vue
@@ -64,9 +64,9 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 
-import { GRAPH, NAMESPACE } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { FilterOptions, TTIriRef } from "vue-library/interfaces";
+import { GRAPH, NAMESPACE } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { FilterOptions, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { useFilterStore } from "@/stores/filterStore";
 

--- a/src/components/shared/IMViewerLink.vue
+++ b/src/components/shared/IMViewerLink.vue
@@ -25,8 +25,8 @@
 <script lang="ts" setup>
 import { onUnmounted, ref, watch } from "vue";
 
-import { OverlaySummary } from "vue-library/components";
-import { useOverlay } from "vue-library/composables";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useOverlay } from "@endeavour/vue-library/composables";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/shared/NavTree.vue
+++ b/src/components/shared/NavTree.vue
@@ -48,15 +48,15 @@
 <script lang="ts" setup>
 import { Ref, computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useTree } from "vue-library/composables";
-import { useOverlay } from "vue-library/composables";
-import { IM } from "vue-library/enums";
-import { UserRole } from "vue-library/enums";
-import { byKey, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useTree } from "@endeavour/vue-library/composables";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { IM } from "@endeavour/vue-library/enums";
+import { UserRole } from "@endeavour/vue-library/enums";
+import { byKey, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { MenuItem } from "primevue/menuitem";

--- a/src/components/shared/ReportTable.vue
+++ b/src/components/shared/ReportTable.vue
@@ -21,8 +21,8 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref } from "vue";
 
-import { OWL, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
+import { OWL, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
 
 interface Props {
   title?: string;

--- a/src/components/shared/ResultsTable.vue
+++ b/src/components/shared/ResultsTable.vue
@@ -96,14 +96,14 @@
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 import { nextTick } from "vue";
 
-import { OverlaySummary } from "vue-library/components";
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { BatteryBar } from "vue-library/components";
-import { useDownloadFile } from "vue-library/composables";
-import { useOverlay } from "vue-library/composables";
-import { TextSearchStyle } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, getNamesAsStringFromTypes } from "vue-library/helpers";
-import { isArrayHasLength } from "vue-library/helpers";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { BatteryBar } from "@endeavour/vue-library/components";
+import { useDownloadFile } from "@endeavour/vue-library/composables";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { TextSearchStyle } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, getNamesAsStringFromTypes } from "@endeavour/vue-library/helpers";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
 import {
   DownloadByQueryOptions,
   ECLQueryRequest,
@@ -111,9 +111,9 @@ import {
   QueryRequest,
   SearchResponse,
   SearchResultSummary
-} from "vue-library/interfaces";
-import type { FilterOptions, Namespace } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+} from "@endeavour/vue-library/interfaces";
+import type { FilterOptions, Namespace } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { DataTablePageEvent, DataTableRowSelectEvent } from "primevue/datatable";

--- a/src/components/shared/SearchBar.vue
+++ b/src/components/shared/SearchBar.vue
@@ -50,9 +50,9 @@
 import { onMounted, ref, watch } from "vue";
 import { Ref } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { useSpeechToText } from "vue-library/composables";
-import type { FilterOptions, SearchResultSummary } from "vue-library/interfaces";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { useSpeechToText } from "@endeavour/vue-library/composables";
+import type { FilterOptions, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import InputGroupAddon from "primevue/inputgroupaddon";
 

--- a/src/components/shared/SearchResults.vue
+++ b/src/components/shared/SearchResults.vue
@@ -77,8 +77,8 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM } from "vue-library/enums";
-import type { FilterOptions, QueryRequest, SearchResponse, SearchResultSummary, TTIriRef } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import type { FilterOptions, QueryRequest, SearchResponse, SearchResultSummary, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 

--- a/src/components/shared/SecondaryTree.vue
+++ b/src/components/shared/SecondaryTree.vue
@@ -75,14 +75,14 @@
 <script setup lang="ts">
 import { Ref, computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import { useUserStore } from "vue-library";
-import { IMFontAwesomeIcon } from "vue-library/components";
-import { OverlaySummary } from "vue-library/components";
-import { useTree } from "vue-library/composables";
-import { useOverlay } from "vue-library/composables";
-import { RDF, RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedEntityReferenceNode, ExtendedTTEntity, TTIriRef } from "vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
+import { OverlaySummary } from "@endeavour/vue-library/components";
+import { useTree } from "@endeavour/vue-library/composables";
+import { useOverlay } from "@endeavour/vue-library/composables";
+import { RDF, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedEntityReferenceNode, ExtendedTTEntity, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 

--- a/src/components/shared/TermCodeTable.vue
+++ b/src/components/shared/TermCodeTable.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, watch } from "vue";
 
-import type { SearchTermCode } from "vue-library/interfaces";
+import type { SearchTermCode } from "@endeavour/vue-library/interfaces";
 
 import { useTerms } from "@/composables/useTerms";
 

--- a/src/components/shared/TopBar.vue
+++ b/src/components/shared/TopBar.vue
@@ -150,9 +150,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { useChangeFontSize, useChangeThemeOptions } from "vue-library/composables";
-import { FontSize, PrimeVueColors, PrimeVuePresetThemes, UserRole } from "vue-library/enums";
-import { useUserStore } from "vue-library/stores";
+import { useChangeFontSize, useChangeThemeOptions } from "@endeavour/vue-library/composables";
+import { FontSize, PrimeVueColors, PrimeVuePresetThemes, UserRole } from "@endeavour/vue-library/enums";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useCookies } from "@vueuse/integrations";
 import Button from "primevue/button";

--- a/src/components/shared/dialogs/DirectorySearchDialog.vue
+++ b/src/components/shared/dialogs/DirectorySearchDialog.vue
@@ -101,9 +101,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { IM, RDFS } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
-import type { FilterOptions, QueryRequest, SearchResponse, SearchResultSummary } from "vue-library/interfaces";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { FilterOptions, QueryRequest, SearchResponse, SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import { SplitterResizeEndEvent } from "primevue/splitter";

--- a/src/components/shared/dialogs/DownloadByQueryOptionsDialog.vue
+++ b/src/components/shared/dialogs/DownloadByQueryOptionsDialog.vue
@@ -94,9 +94,9 @@
 <script lang="ts" setup>
 import { Ref, computed, ref, watch } from "vue";
 
-import { IM, SNOMED } from "vue-library/enums";
-import { NAMESPACE } from "vue-library/enums";
-import type { TTIriRef } from "vue-library/interfaces";
+import { IM, SNOMED } from "@endeavour/vue-library/enums";
+import { NAMESPACE } from "@endeavour/vue-library/enums";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { DownloadSettings } from "@/interfaces";
 import { useFilterStore } from "@/stores/filterStore";

--- a/src/components/shared/dialogs/JSONEditor.vue
+++ b/src/components/shared/dialogs/JSONEditor.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 
-import type { Match } from "vue-library/interfaces";
+import type { Match } from "@endeavour/vue-library/interfaces";
 
 import { isEqual } from "lodash-es";
 

--- a/src/components/shared/dynamicDialogs/AlertDialog.vue
+++ b/src/components/shared/dynamicDialogs/AlertDialog.vue
@@ -33,7 +33,7 @@
 <script setup lang="ts">
 import { Ref, computed, inject, onMounted, ref } from "vue";
 
-import { IMFontAwesomeIcon } from "vue-library/components";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
 
 import { AlertDialogOptions, TypedDynamicDialogOptions } from "@/interfaces";
 import { useDialogStore } from "@/stores/dialogStore";

--- a/src/components/uprn/AddressFileDownload.vue
+++ b/src/components/uprn/AddressFileDownload.vue
@@ -30,7 +30,7 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useToast } from "primevue/usetoast";
 

--- a/src/components/uprn/AddressFileWorkflow.vue
+++ b/src/components/uprn/AddressFileWorkflow.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { isArrayHasLength } from "vue-library/helpers";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
 
 import FileUpload from "primevue/fileupload";
 import { useToast } from "primevue/usetoast";
@@ -49,7 +49,7 @@ const handleFileUpload = async (event: any) => {
       try {
         const result = await UprnService.upload(formData);
         if (result) {
-          if (result.upload.status === "OK") {
+          if (result.upload?.status === "OK") {
             console.log("File uploaded successfully");
             toast.add({ severity: "success", summary: "Success", detail: "File uploaded successfully" });
           } else {

--- a/src/components/uprn/SingleAddressLookup.vue
+++ b/src/components/uprn/SingleAddressLookup.vue
@@ -69,7 +69,7 @@
 <script setup lang="ts">
 import { Ref, computed, ref, watch } from "vue";
 
-import { isObject } from "vue-library/helpers";
+import { isObject } from "@endeavour/vue-library/helpers";
 
 import Button from "primevue/button";
 import { useToast } from "primevue/usetoast";

--- a/src/components/uprn/UprnConsent.vue
+++ b/src/components/uprn/UprnConsent.vue
@@ -91,7 +91,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useRouter } from "vue-router";
 

--- a/src/components/workflow/SideBar.vue
+++ b/src/components/workflow/SideBar.vue
@@ -20,7 +20,7 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { MenuItem } from "primevue/menuitem";
 

--- a/src/components/workflow/TaskHistoryDialog.vue
+++ b/src/components/workflow/TaskHistoryDialog.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script setup lang="ts">
-import { formatDateTime } from "vue-library/helpers";
-import type { TaskHistory } from "vue-library/interfaces";
+import { formatDateTime } from "@endeavour/vue-library/helpers";
+import type { TaskHistory } from "@endeavour/vue-library/interfaces";
 
 interface Props {
   showDialog: boolean;

--- a/src/components/workflow/TaskViewer.vue
+++ b/src/components/workflow/TaskViewer.vue
@@ -75,10 +75,10 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { TaskState, TaskType, UserRole } from "vue-library/enums";
-import type { Task, TaskHistory } from "vue-library/interfaces";
-import { User } from "vue-library/models";
-import { useUserStore } from "vue-library/stores";
+import { TaskState, TaskType, UserRole } from "@endeavour/vue-library/enums";
+import type { Task, TaskHistory } from "@endeavour/vue-library/interfaces";
+import { User } from "@endeavour/vue-library/models";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import TaskHistoryDialog from "@/components/workflow/TaskHistoryDialog.vue";
 import SecurityService from "@/services/SecurityService";

--- a/src/components/workflow/ViewBugReport.vue
+++ b/src/components/workflow/ViewBugReport.vue
@@ -126,9 +126,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { Browser, OperatingSystem, TaskModule } from "vue-library/enums";
-import type { BugReport, Task } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { Browser, OperatingSystem, TaskModule } from "@endeavour/vue-library/enums";
+import type { BugReport, Task } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 

--- a/src/components/workflow/ViewEntityApproval.vue
+++ b/src/components/workflow/ViewEntityApproval.vue
@@ -39,9 +39,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { ApprovalType } from "vue-library/enums";
-import type { EntityApproval, Task } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { ApprovalType } from "@endeavour/vue-library/enums";
+import type { EntityApproval, Task } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 

--- a/src/components/workflow/ViewNamespaceRequest.vue
+++ b/src/components/workflow/ViewNamespaceRequest.vue
@@ -41,9 +41,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { NAMESPACE } from "vue-library/enums";
-import type { Namespace, NamespaceRequest, Task } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { NAMESPACE } from "@endeavour/vue-library/enums";
+import type { Namespace, NamespaceRequest, Task } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 

--- a/src/components/workflow/ViewRoleRequest.vue
+++ b/src/components/workflow/ViewRoleRequest.vue
@@ -33,9 +33,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { UserRole } from "vue-library/enums";
-import type { RoleRequest, Task } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { UserRole } from "@endeavour/vue-library/enums";
+import type { RoleRequest, Task } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useConfirm } from "primevue/useconfirm";
 

--- a/src/components/workflow/WorkflowTable.vue
+++ b/src/components/workflow/WorkflowTable.vue
@@ -49,9 +49,9 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref } from "vue";
 
-import { TaskType } from "vue-library/enums";
-import { formatDateTime } from "vue-library/helpers";
-import type { Task, TaskHistory, WorkflowResponse } from "vue-library/interfaces";
+import { TaskType } from "@endeavour/vue-library/enums";
+import { formatDateTime } from "@endeavour/vue-library/helpers";
+import type { Task, TaskHistory, WorkflowResponse } from "@endeavour/vue-library/interfaces";
 
 import { useRouter } from "vue-router";
 

--- a/src/composables/useCreateNew.ts
+++ b/src/composables/useCreateNew.ts
@@ -1,8 +1,8 @@
 import { Ref } from "vue";
 
-import { IM, RDFS, SHACL } from "vue-library/enums";
-import { getFAIconFromType, isArrayHasLength } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
+import { IM, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { getFAIconFromType, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { MenuItem } from "primevue/menuitem";
 import type { TreeNode } from "primevue/treenode";

--- a/src/composables/useDirectService.ts
+++ b/src/composables/useDirectService.ts
@@ -1,4 +1,4 @@
-import { RecentActivityItemDto, useUserStore } from "vue-library";
+import { RecentActivityItemDto, useUserStore } from "@endeavour/vue-library";
 
 import { LocationQuery, useRouter } from "vue-router";
 

--- a/src/composables/useDragContext.ts
+++ b/src/composables/useDragContext.ts
@@ -1,4 +1,4 @@
-import type { Match, Where } from "vue-library/interfaces";
+import type { Match, Where } from "@endeavour/vue-library/interfaces";
 
 type DraggedItem = {
   clause: Match | Where;

--- a/src/composables/useEditorEntity.ts
+++ b/src/composables/useEditorEntity.ts
@@ -1,8 +1,8 @@
 import { Ref, computed, ref } from "vue";
 
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { TTIriRef } from "vue-library/interfaces";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { isEqual } from "lodash-es";
 

--- a/src/composables/useEditorShape.ts
+++ b/src/composables/useEditorShape.ts
@@ -1,8 +1,8 @@
 import { Ref, ref } from "vue";
 
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { FormGenerator, PropertyShape, TTIriRef } from "vue-library/interfaces";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { FormGenerator, PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import editorShapes from "@/constants/editorShapes";
 import { EditorMode } from "@/enums";

--- a/src/composables/usePropertyTree.ts
+++ b/src/composables/usePropertyTree.ts
@@ -1,8 +1,8 @@
 import { Ref, ref } from "vue";
 
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isArrayHasLength } from "vue-library/helpers";
-import type { Match, Node, NodeShape, PropertyShape, TTIriRef, Where } from "vue-library/interfaces";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Match, Node, NodeShape, PropertyShape, TTIriRef, Where } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 

--- a/src/composables/useReturnTrees.ts
+++ b/src/composables/useReturnTrees.ts
@@ -1,8 +1,8 @@
 import { Ref, ref } from "vue";
 
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
-import { getColourFromType, getFAIconFromType, isArrayHasLength } from "vue-library/helpers";
-import type { Node, PropertyShape } from "vue-library/interfaces";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { getColourFromType, getFAIconFromType, isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Node, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import type { TreeNode } from "primevue/treenode";
 

--- a/src/composables/useTerms.ts
+++ b/src/composables/useTerms.ts
@@ -1,6 +1,6 @@
 import { Ref, ref } from "vue";
 
-import type { SearchTermCode } from "vue-library/interfaces";
+import type { SearchTermCode } from "@endeavour/vue-library/interfaces";
 
 import { ConceptService } from "@/services";
 

--- a/src/composables/useValidity.ts
+++ b/src/composables/useValidity.ts
@@ -1,8 +1,8 @@
 import { Ref, ref } from "vue";
 
-import { COMPONENT, IM } from "vue-library/enums";
-import { TypeGuards, deferred, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { FormGenerator, PropertyShape } from "vue-library/interfaces";
+import { COMPONENT, IM } from "@endeavour/vue-library/enums";
+import { TypeGuards, deferred, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { FormGenerator, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { isArray } from "lodash-es";
 

--- a/src/composables/useValueVariableMap.ts
+++ b/src/composables/useValueVariableMap.ts
@@ -1,7 +1,7 @@
 import { Ref, ref } from "vue";
 
-import { isArrayHasLength } from "vue-library/helpers";
-import type { PropertyShape } from "vue-library/interfaces";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 export function useValueVariableMap() {
   const valueVariableMap: Ref<Map<string, any>> = ref(new Map<string, any>());

--- a/src/constants/editorShapes/CohortQuery.ts
+++ b/src/constants/editorShapes/CohortQuery.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const CohortQueryShape: FormGenerator = {
   iri: EDITOR.COHORT_QUERY_SHAPE,

--- a/src/constants/editorShapes/Concept.ts
+++ b/src/constants/editorShapes/Concept.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, NAMESPACE, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, NAMESPACE, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const ConceptShape: FormGenerator = {
   iri: EDITOR.CONCEPT_SHAPE,

--- a/src/constants/editorShapes/ConcetSet.ts
+++ b/src/constants/editorShapes/ConcetSet.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const ConceptSetShape: FormGenerator = {
   iri: EDITOR.CONCEPT_SET_SHAPE,

--- a/src/constants/editorShapes/DataModel.ts
+++ b/src/constants/editorShapes/DataModel.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, SHACL, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, SHACL, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const DataModelShape: FormGenerator = {
   iri: EDITOR.DATA_MODEL_SHAPE,

--- a/src/constants/editorShapes/Folder.ts
+++ b/src/constants/editorShapes/Folder.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const FolderShape: FormGenerator = {
   iri: EDITOR.FOLDER_SHAPE,

--- a/src/constants/editorShapes/Indicator.ts
+++ b/src/constants/editorShapes/Indicator.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const IndicatorShape: FormGenerator = {
   iri: EDITOR.INDICATOR_SHAPE,

--- a/src/constants/editorShapes/Property.ts
+++ b/src/constants/editorShapes/Property.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const PropertyShape: FormGenerator = {
   iri: EDITOR.PROPERTY_SHAPE,

--- a/src/constants/editorShapes/ValueSet.ts
+++ b/src/constants/editorShapes/ValueSet.ts
@@ -1,5 +1,5 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
-import type { FormGenerator } from "vue-library/interfaces";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
+import type { FormGenerator } from "@endeavour/vue-library/interfaces";
 
 const ValueSetShape: FormGenerator = {
   iri: EDITOR.VALUE_SET_SHAPE,

--- a/src/constants/queryEditor/OperatorOptions.ts
+++ b/src/constants/queryEditor/OperatorOptions.ts
@@ -1,4 +1,4 @@
-import { Operator } from "vue-library";
+import { Operator } from "@endeavour/vue-library";
 
 export const OperatorOptions: { label: string; value: Operator; tooltip: string }[] = [
   {

--- a/src/helpers/DetailsBuilder.ts
+++ b/src/helpers/DetailsBuilder.ts
@@ -1,6 +1,6 @@
-import { IM, RDFS, SHACL } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { TTBundle, TTIriRef } from "vue-library/interfaces";
+import { IM, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTBundle, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export function buildDetails(definition: TTBundle): any[] {
   const treeNode = { children: [] as any[] };

--- a/src/helpers/EditorBuilderJsonMethods.ts
+++ b/src/helpers/EditorBuilderJsonMethods.ts
@@ -1,4 +1,4 @@
-import type { PropertyShape } from "vue-library/interfaces";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { EditorMode } from "../enums";
 import { ComponentType } from "../enums/ComponentType";

--- a/src/helpers/EditorMethods.ts
+++ b/src/helpers/EditorMethods.ts
@@ -1,6 +1,6 @@
-import { IM, RDF, RDFS, SHACL } from "vue-library/enums";
-import { TypeGuards, enumToArray, isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { Argument, GenericObject, PropertyShape, QueryRequest, TTIriRef } from "vue-library/interfaces";
+import { IM, RDF, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { TypeGuards, enumToArray, isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Argument, GenericObject, PropertyShape, QueryRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { ComponentType } from "../enums";
 

--- a/src/helpers/GraphTranslator.ts
+++ b/src/helpers/GraphTranslator.ts
@@ -1,6 +1,6 @@
-import { IM, NAMESPACE, OWL, RDFS, SHACL } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, GenericObject, TTBundle, TTIriRef } from "vue-library/interfaces";
+import { IM, NAMESPACE, OWL, RDFS, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, GenericObject, TTBundle, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { TTGraphData, TTProperty } from "../interfaces";
 

--- a/src/helpers/QueryEditorMethods.ts
+++ b/src/helpers/QueryEditorMethods.ts
@@ -1,5 +1,5 @@
-import { Operator, Order } from "vue-library/enums";
-import type { Compare, Having, Match, Node, Orderable, Range, Where } from "vue-library/interfaces";
+import { Operator, Order } from "@endeavour/vue-library/enums";
+import type { Compare, Having, Match, Node, Orderable, Range, Where } from "@endeavour/vue-library/interfaces";
 
 import { ConstraintOperatorKey, ConstraintOperatorMap } from "@/constants/queryEditor/ConstraintOperatorMap";
 import { SentencePart } from "@/interfaces";

--- a/src/helpers/TTTransform.ts
+++ b/src/helpers/TTTransform.ts
@@ -1,6 +1,6 @@
-import { NAMESPACE } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
-import type { ExtendedTTEntity, GenericObject, TTIriRef } from "vue-library/interfaces";
+import { NAMESPACE } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity, GenericObject, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export function transformTT(ttEntity: ExtendedTTEntity, map?: GenericObject) {
   if (!isObjectHasKeys(ttEntity)) return {} as ExtendedTTEntity;

--- a/src/helpers/Transforms.ts
+++ b/src/helpers/Transforms.ts
@@ -1,6 +1,6 @@
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { Argument, GenericObject } from "vue-library/interfaces";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { Argument, GenericObject } from "@endeavour/vue-library/interfaces";
 
 export function mapToObject(args: Argument[]) {
   const argsAsObject = {} as Argument;

--- a/src/helpers/buildQuery.ts
+++ b/src/helpers/buildQuery.ts
@@ -1,5 +1,5 @@
-import { Bool, IM, RDF, RuleAction, SHACL } from "vue-library/enums";
-import { isArrayHasLength } from "vue-library/helpers";
+import { Bool, IM, RDF, RuleAction, SHACL } from "@endeavour/vue-library/enums";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
 import type {
   HasPaths,
   Having,
@@ -14,7 +14,7 @@ import type {
   Return,
   SearchBinding,
   Where
-} from "vue-library/interfaces";
+} from "@endeavour/vue-library/interfaces";
 
 import { cloneDeep } from "lodash-es";
 import type { TreeNode } from "primevue/treenode";

--- a/src/injectionKeys/injectionKeys.ts
+++ b/src/injectionKeys/injectionKeys.ts
@@ -1,6 +1,6 @@
 import type { InjectionKey, Ref } from "vue";
 
-import type { ExtendedTTEntity, FormGenerator, GenericObject, PropertyShape } from "vue-library/interfaces";
+import type { ExtendedTTEntity, FormGenerator, GenericObject, PropertyShape } from "@endeavour/vue-library/interfaces";
 
 const editorValidity = Symbol("editorValidity") as InjectionKey<{
   validity: Ref<{ key: string; valid: boolean }[]>;

--- a/src/interfaces/AliasEntity.ts
+++ b/src/interfaces/AliasEntity.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface AliasEntity {
   iri?: string;

--- a/src/interfaces/AllowableChildProperty.ts
+++ b/src/interfaces/AllowableChildProperty.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export default interface AllowableChildProperty {
   iri: string;

--- a/src/interfaces/CodeTemplate.ts
+++ b/src/interfaces/CodeTemplate.ts
@@ -1,4 +1,4 @@
-import type { GenericObject } from "vue-library/interfaces";
+import type { GenericObject } from "@endeavour/vue-library/interfaces";
 
 export interface CodeTemplate {
   name: string;

--- a/src/interfaces/ComponentDetails.ts
+++ b/src/interfaces/ComponentDetails.ts
@@ -1,4 +1,4 @@
-import type { PropertyShape } from "vue-library/interfaces";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { ComponentType, EditorMode } from "../enums";
 

--- a/src/interfaces/ConceptAggregate.ts
+++ b/src/interfaces/ConceptAggregate.ts
@@ -1,4 +1,4 @@
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 export interface ConceptAggregate {
   children: ExtendedTTEntity[];

--- a/src/interfaces/CustomAlert.ts
+++ b/src/interfaces/CustomAlert.ts
@@ -1,4 +1,4 @@
-import { User } from "vue-library/models";
+import { User } from "@endeavour/vue-library/models";
 
 export interface CustomAlert {
   status: number;

--- a/src/interfaces/DownloadSettings.ts
+++ b/src/interfaces/DownloadSettings.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface DownloadSettings {
   selectedFormat: string;

--- a/src/interfaces/EclRefinement.ts
+++ b/src/interfaces/EclRefinement.ts
@@ -1,4 +1,4 @@
-import type { SearchResultSummary } from "vue-library/interfaces";
+import type { SearchResultSummary } from "@endeavour/vue-library/interfaces";
 
 export interface EclRefinement {
   type: string;

--- a/src/interfaces/Entity.ts
+++ b/src/interfaces/Entity.ts
@@ -1,4 +1,4 @@
-import type { GenericObject } from "vue-library/interfaces";
+import type { GenericObject } from "@endeavour/vue-library/interfaces";
 
 export interface EntityReference {
   iri: string;

--- a/src/interfaces/ExportValueSet.ts
+++ b/src/interfaces/ExportValueSet.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 import { ValueSetMember } from "./ValueSetMember";
 

--- a/src/interfaces/ExtendedRecentActivityItem.ts
+++ b/src/interfaces/ExtendedRecentActivityItem.ts
@@ -1,4 +1,4 @@
-import { RecentActivityItem } from "vue-library/models";
+import { RecentActivityItem } from "@endeavour/vue-library/models";
 
 export interface ExtendedRecentActivityItem extends RecentActivityItem {
   name: string;

--- a/src/interfaces/Property.ts
+++ b/src/interfaces/Property.ts
@@ -1,4 +1,4 @@
-import type { GenericObject, TTIriRef } from "vue-library/interfaces";
+import type { GenericObject, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface Property extends GenericObject {
   "http://www.w3.org/ns/shacl#path": TTIriRef[];

--- a/src/interfaces/PropertyDisplay.ts
+++ b/src/interfaces/PropertyDisplay.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface PropertyDisplay {
   order?: number;

--- a/src/interfaces/RelativeTo.ts
+++ b/src/interfaces/RelativeTo.ts
@@ -1,4 +1,4 @@
-import { TTIriRef } from "vue-library";
+import { TTIriRef } from "@endeavour/vue-library";
 
 export type RelativeTo = {
   nodeRef?: string;

--- a/src/interfaces/SearchOptions.ts
+++ b/src/interfaces/SearchOptions.ts
@@ -1,4 +1,4 @@
-import type { FilterOptions, Page, SearchBinding, TTIriRef } from "vue-library/interfaces";
+import type { FilterOptions, Page, SearchBinding, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface SearchOptions extends FilterOptions {
   isA?: TTIriRef[];

--- a/src/interfaces/SelectedMatch.ts
+++ b/src/interfaces/SelectedMatch.ts
@@ -1,4 +1,4 @@
-import type { Match } from "vue-library/interfaces";
+import type { Match } from "@endeavour/vue-library/interfaces";
 
 export interface SelectedMatch {
   selected: Match;

--- a/src/interfaces/SetDiffObject.ts
+++ b/src/interfaces/SetDiffObject.ts
@@ -1,4 +1,4 @@
-import type { Concept } from "vue-library/interfaces";
+import type { Concept } from "@endeavour/vue-library/interfaces";
 
 export interface SetDiffObject {
   membersA: Concept[];

--- a/src/interfaces/TTProperty.ts
+++ b/src/interfaces/TTProperty.ts
@@ -1,4 +1,4 @@
-import type { GenericObject, TTIriRef } from "vue-library/interfaces";
+import type { GenericObject, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface TTProperty extends GenericObject {
   "http://www.w3.org/ns/shacl#order": number;

--- a/src/interfaces/TangledTreeData.ts
+++ b/src/interfaces/TangledTreeData.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export default interface TangledTreeData {
   id: string;

--- a/src/interfaces/TreeNode.ts
+++ b/src/interfaces/TreeNode.ts
@@ -1,4 +1,4 @@
-import type { GenericObject, TTIriRef } from "vue-library/interfaces";
+import type { GenericObject, TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface TreeNode extends GenericObject {
   key: string;

--- a/src/interfaces/ValidatedEntity.ts
+++ b/src/interfaces/ValidatedEntity.ts
@@ -1,4 +1,4 @@
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 export interface ValidatedEntity extends ExtendedTTEntity {
   validationCode?: string;

--- a/src/interfaces/ValueSetMember.ts
+++ b/src/interfaces/ValueSetMember.ts
@@ -1,4 +1,4 @@
-import type { TTIriRef } from "vue-library/interfaces";
+import type { TTIriRef } from "@endeavour/vue-library/interfaces";
 
 export interface ValueSetMember {
   entity: TTIriRef;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { ComponentPublicInstance, createApp } from "vue";
 
-import { injectionKeysVueLibrary } from "vue-library";
-import { IMFontAwesomeIcon } from "vue-library/components";
+import { injectionKeysVueLibrary } from "@endeavour/vue-library";
+import { IMFontAwesomeIcon } from "@endeavour/vue-library/components";
 
 import Aura from "@primeuix/themes/aura";
 import { createPinia } from "pinia";

--- a/src/mocks/fakerFactory.ts
+++ b/src/mocks/fakerFactory.ts
@@ -1,4 +1,4 @@
-import { UserSchema } from "vue-library";
+import { UserSchema } from "@endeavour/vue-library";
 
 import { faker } from "@faker-js/faker";
 import { Collection } from "@msw/data";

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
-import { IM } from "vue-library/enums";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import { IM } from "@endeavour/vue-library/enums";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import { faker } from "@faker-js/faker";
 import { isArray } from "lodash-es";

--- a/src/models/customErrors/ApiError.ts
+++ b/src/models/customErrors/ApiError.ts
@@ -1,4 +1,4 @@
-import { dateNow, timeNow } from "vue-library/helpers";
+import { dateNow, timeNow } from "@endeavour/vue-library/helpers";
 
 export default class ApiError extends Error {
   status: number;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,8 @@
+import { useUserStore } from "@endeavour/vue-library/stores";
+
 import { createRouter, createWebHashHistory } from "vue-router";
 
+import { SecurityService } from "@/services";
 import { useAuthStore } from "@/stores/authStore";
 
 import { setBrowserTabTitles } from "./methods/browserTabTitles";
@@ -26,8 +29,6 @@ import {
 } from "./methods/routeGuards";
 import routes from "./methods/routes";
 import { setModes } from "./methods/setModes";
-import { SecurityService } from "@/services";
-import { useUserStore } from "vue-library/stores";
 
 const router = createRouter({
   history: createWebHashHistory(),

--- a/src/router/methods/metaGuards.ts
+++ b/src/router/methods/metaGuards.ts
@@ -1,7 +1,7 @@
 import { computed } from "vue";
 
-import { UserRole } from "vue-library/enums";
-import { useUserStore } from "vue-library/stores";
+import { UserRole } from "@endeavour/vue-library/enums";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { RouteLocationNormalized, Router } from "vue-router";
 

--- a/src/router/methods/routeGuards.ts
+++ b/src/router/methods/routeGuards.ts
@@ -1,4 +1,4 @@
-import { isObjectHasKeys, urlToIri } from "vue-library/helpers";
+import { isObjectHasKeys, urlToIri } from "@endeavour/vue-library/helpers";
 
 import { RouteLocationNormalized, Router } from "vue-router";
 

--- a/src/services/CodeGenService.ts
+++ b/src/services/CodeGenService.ts
@@ -1,4 +1,4 @@
-import type { CodeGenDto } from "vue-library/interfaces";
+import type { CodeGenDto } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/ConceptService.ts
+++ b/src/services/ConceptService.ts
@@ -1,4 +1,4 @@
-import type { ConceptContextMap } from "vue-library/interfaces";
+import type { ConceptContextMap } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -1,4 +1,4 @@
-import type { Namespace } from "vue-library/interfaces";
+import type { Namespace } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/DataModelService.ts
+++ b/src/services/DataModelService.ts
@@ -1,4 +1,4 @@
-import type { NodeShape, TTIriRef, UIProperty } from "vue-library/interfaces";
+import type { NodeShape, TTIriRef, UIProperty } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/EclService.ts
+++ b/src/services/EclService.ts
@@ -1,4 +1,4 @@
-import type { ECLQueryRequest, Query, SearchResponse } from "vue-library/interfaces";
+import type { ECLQueryRequest, Query, SearchResponse } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/EntityService.ts
+++ b/src/services/EntityService.ts
@@ -1,5 +1,5 @@
-import { IM, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
 import {
   DownloadByQueryOptions,
   EditRequest,
@@ -13,7 +13,7 @@ import {
   SearchResultSummary,
   TTBundle,
   TTIriRef
-} from "vue-library/interfaces";
+} from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 import { OrganizationChartNode } from "primevue/organizationchart";

--- a/src/services/FilerService.ts
+++ b/src/services/FilerService.ts
@@ -1,5 +1,5 @@
-import { NAMESPACE } from "vue-library/enums";
-import type { ExtendedTTEntity, TTDocument } from "vue-library/interfaces";
+import { NAMESPACE } from "@endeavour/vue-library/enums";
+import type { ExtendedTTEntity, TTDocument } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/FunctionService.ts
+++ b/src/services/FunctionService.ts
@@ -1,5 +1,5 @@
-import { isArrayHasLength } from "vue-library/helpers";
-import type { Argument } from "vue-library/interfaces";
+import { isArrayHasLength } from "@endeavour/vue-library/helpers";
+import type { Argument } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -1,5 +1,5 @@
-import { REPO } from "vue-library/enums";
-import type { GithubRelease } from "vue-library/interfaces";
+import { REPO } from "@endeavour/vue-library/enums";
+import type { GithubRelease } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/QueryService.ts
+++ b/src/services/QueryService.ts
@@ -1,5 +1,5 @@
-import { DisplayMode } from "vue-library/enums";
-import { isArrayHasLength, isObjectHasKeys } from "vue-library/helpers";
+import { DisplayMode } from "@endeavour/vue-library/enums";
+import { isArrayHasLength, isObjectHasKeys } from "@endeavour/vue-library/helpers";
 import {
   ArgumentReference,
   ExtendedTTEntity,
@@ -11,7 +11,7 @@ import {
   QueryRequest,
   Return,
   SearchResponse
-} from "vue-library/interfaces";
+} from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -1,5 +1,5 @@
-import { UserRole } from "vue-library/enums";
-import { User } from "vue-library/models";
+import { UserRole } from "@endeavour/vue-library/enums";
+import { User } from "@endeavour/vue-library/models";
 
 import axios from "axios";
 

--- a/src/services/SetService.ts
+++ b/src/services/SetService.ts
@@ -1,5 +1,5 @@
-import type { ECLQueryRequest, Node, Pageable, Query, SetExportRequest, TTIriRef } from "vue-library/interfaces";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
+import type { ECLQueryRequest, Node, Pageable, Query, SetExportRequest, TTIriRef } from "@endeavour/vue-library/interfaces";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,6 +1,6 @@
-import { PrimeVueColors, PrimeVuePresetThemes } from "vue-library/enums";
-import type { RecentActivityItemDto } from "vue-library/interfaces";
-import { NamespacePermission, User } from "vue-library/models";
+import { PrimeVueColors, PrimeVuePresetThemes } from "@endeavour/vue-library/enums";
+import type { RecentActivityItemDto } from "@endeavour/vue-library/interfaces";
+import { NamespacePermission, User } from "@endeavour/vue-library/models";
 
 import axios from "axios";
 

--- a/src/services/WorkflowService.ts
+++ b/src/services/WorkflowService.ts
@@ -1,4 +1,4 @@
-import type { BugReport, EntityApproval, NamespaceRequest, RoleRequest, Task, WorkflowResponse } from "vue-library/interfaces";
+import type { BugReport, EntityApproval, NamespaceRequest, RoleRequest, Task, WorkflowResponse } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 

--- a/src/stores/creatorStore.ts
+++ b/src/stores/creatorStore.ts
@@ -1,8 +1,8 @@
 import { ref } from "vue";
 
-import { localStorageWithExpiry } from "vue-library/helpers";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { localStorageWithExpiry } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { defineStore } from "pinia";
 

--- a/src/stores/directoryStore.ts
+++ b/src/stores/directoryStore.ts
@@ -1,8 +1,8 @@
 import { ref } from "vue";
 
-import { IM, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { SearchResponse } from "vue-library/interfaces";
+import { IM, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { SearchResponse } from "@endeavour/vue-library/interfaces";
 
 import { defineStore } from "pinia";
 

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,10 +1,10 @@
 import { ref } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import { localStorageWithExpiry } from "vue-library/helpers";
-import type { ExtendedTTEntity } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import { localStorageWithExpiry } from "@endeavour/vue-library/helpers";
+import type { ExtendedTTEntity } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { defineStore } from "pinia";
 

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -1,7 +1,7 @@
 import { ref } from "vue";
 
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { FilterOptions, Namespace } from "vue-library/interfaces";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { FilterOptions, Namespace } from "@endeavour/vue-library/interfaces";
 
 import { defineStore } from "pinia";
 

--- a/src/stores/queryStore.ts
+++ b/src/stores/queryStore.ts
@@ -1,8 +1,8 @@
 import { ref } from "vue";
 
-import { RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { QueryRequest } from "vue-library/interfaces";
+import { RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { QueryRequest } from "@endeavour/vue-library/interfaces";
 
 import { defineStore } from "pinia";
 

--- a/src/stores/sharedStore.ts
+++ b/src/stores/sharedStore.ts
@@ -1,7 +1,7 @@
 import { ref } from "vue";
 
-import { IM, TagSeverity } from "vue-library/enums";
-import { localStorageWithExpiry } from "vue-library/helpers";
+import { IM, TagSeverity } from "@endeavour/vue-library/enums";
+import { localStorageWithExpiry } from "@endeavour/vue-library/helpers";
 
 import { defineStore } from "pinia";
 

--- a/src/views/BugReport.vue
+++ b/src/views/BugReport.vue
@@ -114,9 +114,9 @@
 <script setup lang="ts">
 import { Ref, computed, onMounted, ref, watch } from "vue";
 
-import { Browser, OperatingSystem, REPO, Status, TaskModule, TaskState, TaskType } from "vue-library/enums";
-import type { BugReport } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { Browser, OperatingSystem, REPO, Status, TaskModule, TaskState, TaskType } from "@endeavour/vue-library/enums";
+import type { BugReport } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useRouter } from "vue-router";
 

--- a/src/views/Callback.vue
+++ b/src/views/Callback.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { onMounted } from "vue";
 
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { useRoute, useRouter } from "vue-router";
 

--- a/src/views/CodeGen.vue
+++ b/src/views/CodeGen.vue
@@ -81,7 +81,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 
-import { XSD } from "vue-library/enums";
+import { XSD } from "@endeavour/vue-library/enums";
 
 import { cloneDeep, debounce } from "lodash-es";
 import { useToast } from "primevue/usetoast";

--- a/src/views/Creator.vue
+++ b/src/views/Creator.vue
@@ -95,11 +95,11 @@ export default defineComponent({
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, onMounted, onUnmounted, provide, ref, watch } from "vue";
 
-import { DisplayMode } from "vue-library/enums";
-import { IM, RDF, RDFS } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { DisplayMode } from "@endeavour/vue-library/enums";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { useDialog } from "primevue/usedialog";

--- a/src/views/Directory.vue
+++ b/src/views/Directory.vue
@@ -29,7 +29,7 @@
 <script setup lang="ts">
 import { ComputedRef, Ref, computed, ref } from "vue";
 
-import type { FilterOptions } from "vue-library/interfaces";
+import type { FilterOptions } from "@endeavour/vue-library/interfaces";
 
 import { useRouter } from "vue-router";
 

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -88,10 +88,10 @@ export default defineComponent({
 <script lang="ts" setup>
 import { ComputedRef, Ref, computed, onBeforeUnmount, onMounted, onUnmounted, provide, ref, watch } from "vue";
 
-import { IM, RDF } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { PropertyShape, TTIriRef } from "vue-library/interfaces";
-import { useUserStore } from "vue-library/stores";
+import { IM, RDF } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { PropertyShape, TTIriRef } from "@endeavour/vue-library/interfaces";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { cloneDeep } from "lodash-es";
 import { useDialog } from "primevue/usedialog";

--- a/src/views/Filer.vue
+++ b/src/views/Filer.vue
@@ -28,10 +28,10 @@
 <script setup lang="ts">
 import { Ref, ref } from "vue";
 
-import { IM, ToastSeverity } from "vue-library/enums";
-import { isObjectHasKeys } from "vue-library/helpers";
-import type { TTDocument } from "vue-library/interfaces";
-import { ToastOptions } from "vue-library/models";
+import { IM, ToastSeverity } from "@endeavour/vue-library/enums";
+import { isObjectHasKeys } from "@endeavour/vue-library/helpers";
+import type { TTDocument } from "@endeavour/vue-library/interfaces";
+import { ToastOptions } from "@endeavour/vue-library/models";
 
 import * as d3 from "d3";
 import FileUpload, { FileUploadUploadEvent } from "primevue/fileupload";

--- a/tests/unit/composables/setupEditorEntity.spec.js
+++ b/tests/unit/composables/setupEditorEntity.spec.js
@@ -1,4 +1,4 @@
-import { IM, SHACL } from "vue-library/enums";
+import { IM, SHACL } from "@endeavour/vue-library/enums";
 
 import { expect, vi } from "vitest";
 

--- a/tests/unit/composables/setupEditorShape.spec.js
+++ b/tests/unit/composables/setupEditorShape.spec.js
@@ -1,4 +1,4 @@
-import { IM } from "vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
 
 import { expect, vi } from "vitest";
 

--- a/tests/unit/composables/useValidity.spec.js
+++ b/tests/unit/composables/useValidity.spec.js
@@ -1,6 +1,6 @@
 import { ref } from "vue";
 
-import { IM } from "vue-library/enums";
+import { IM } from "@endeavour/vue-library/enums";
 
 import { flushPromises } from "@vue/test-utils";
 import { cloneDeep } from "lodash-es";

--- a/tests/unit/composables/useValidity.testData.ts
+++ b/tests/unit/composables/useValidity.testData.ts
@@ -1,4 +1,4 @@
-import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "vue-library/enums";
+import { COMPONENT, EDITOR, IM, IM_FUNCTION, QUERY, RDF, RDFS, VALIDATION, XSD } from "@endeavour/vue-library/enums";
 
 import { expect } from "vitest";
 

--- a/tests/unit/helpers/EditorMethods.spec.ts
+++ b/tests/unit/helpers/EditorMethods.spec.ts
@@ -1,5 +1,5 @@
-import { COMPONENT } from "vue-library/enums";
-import type { PropertyShape } from "vue-library/interfaces";
+import { COMPONENT } from "@endeavour/vue-library/enums";
+import type { PropertyShape } from "@endeavour/vue-library/interfaces";
 
 import { describe, expect, it } from "vitest";
 

--- a/tests/unit/helpers/TTTransform.testData.ts
+++ b/tests/unit/helpers/TTTransform.testData.ts
@@ -1,4 +1,4 @@
-import { XSD } from "vue-library/enums";
+import { XSD } from "@endeavour/vue-library/enums";
 
 export const OntologiesFolderTTEntity = {
   iri: "http://endhealth.info/im#HealthModelOntology",

--- a/tests/unit/services/EclService.spec.ts
+++ b/tests/unit/services/EclService.spec.ts
@@ -1,4 +1,4 @@
-import type { ECLQueryRequest, Query } from "vue-library/interfaces";
+import type { ECLQueryRequest, Query } from "@endeavour/vue-library/interfaces";
 
 import axios from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/tests/unit/stores/directoryStore.spec.ts
+++ b/tests/unit/stores/directoryStore.spec.ts
@@ -1,4 +1,4 @@
-import type { SearchResponse } from "vue-library/interfaces";
+import type { SearchResponse } from "@endeavour/vue-library/interfaces";
 
 import { createTestingPinia } from "@pinia/testing";
 import { beforeEach, describe, expect, vi } from "vitest";

--- a/tests/unit/stores/filterStore.spec.ts
+++ b/tests/unit/stores/filterStore.spec.ts
@@ -1,5 +1,5 @@
-import { IM, RDF, RDFS } from "vue-library/enums";
-import type { FilterOptions } from "vue-library/interfaces";
+import { IM, RDF, RDFS } from "@endeavour/vue-library/enums";
+import type { FilterOptions } from "@endeavour/vue-library/interfaces";
 
 import { createTestingPinia } from "@pinia/testing";
 import { beforeEach, describe, expect, vi } from "vitest";

--- a/tests/unit/stores/sharedStore.spec.ts
+++ b/tests/unit/stores/sharedStore.spec.ts
@@ -1,4 +1,4 @@
-import { useUserStore } from "vue-library/stores";
+import { useUserStore } from "@endeavour/vue-library/stores";
 
 import { createTestingPinia } from "@pinia/testing";
 import { beforeEach, describe, expect, vi } from "vitest";


### PR DESCRIPTION
- Updated all import paths from "vue-library/*" to "@endeavour/vue-library/*"
- Standardized library references across the entire codebase
- Maintained consistent import structure in components, stores, services, and interfaces
- Ensured proper module resolution for shared enums, helpers, interfaces, and models