### PR TITLE
chore(package): rename preinstall script to pnpm:devPreinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean-install": "rimraf pnpm-lock.yaml && rimraf node_modules && pnpm install",
     "stop-only": "node stop-only.js",
     "prepare": "husky",
-    "preinstall": "pnpm config set \"@endeavour:registry\" https://artifactory.endhealth.co.uk/repository/npm/"
+    "pnpm:devPreinstall": "pnpm config set \"@endeavour:registry\" https://artifactory.endhealth.co.uk/repository/npm/"
   },
   "dependencies": {
     "@braintree/sanitize-url": "7.1.2",


### PR DESCRIPTION
- Renamed preinstall script to pnpm:devPreinstall to better reflect its purpose
- Maintained same registry configuration functionality
- Ensured consistent naming convention for pnpm-specific scripts