### PR TITLE
refactor(router): unify role-based access control using `requiresRole`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { useDirectService } from "./composables/useDirectService";
 import { worker } from "./mocks/browser";
 import router from "./router";
 import { EntityService, UserService } from "./services";
+import { UserRole } from "@endeavour/vue-library/enums";
 
 declare module "axios" {
   export interface AxiosRequestConfig {
@@ -34,6 +35,7 @@ declare module "axios" {
 declare module "vue-router" {
   interface RouteMeta {
     requiresLicense?: boolean;
+    requiresRole?: UserRole[];
     transition?: string;
     mode?: "in-out" | "out-in" | "default" | undefined;
     transitionDelay?: string;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,12 +8,10 @@ import { useAuthStore } from "@/stores/authStore";
 import { setBrowserTabTitles } from "./methods/browserTabTitles";
 import { endRouterLoading, startRouterLoading } from "./methods/loading";
 import {
-  requiresAdmin,
   requiresAuthGuard,
-  requiresCreateRole,
-  requiresEditRole,
   requiresOrganisation,
   requiresReAuth,
+  requiresRole,
   requiresSnomedLicense,
   requiresUprnAgreement
 } from "./methods/metaGuards";
@@ -55,13 +53,9 @@ router.beforeEach(async (to, from) => {
   let routedByGuard: boolean;
   routedByGuard = await requiresAuthGuard(to, from, router);
   if (routedByGuard) return false;
-  routedByGuard = await requiresAdmin(to, from, router);
-  if (routedByGuard) return false;
   routedByGuard = await requiresReAuth(to, from, router);
   if (routedByGuard) return false;
-  routedByGuard = await requiresCreateRole(to, from, router);
-  if (routedByGuard) return false;
-  routedByGuard = await requiresEditRole(to, from, router);
+  routedByGuard = await requiresRole(to, from, router);
   if (routedByGuard) return false;
   requiresSnomedLicense(to);
   requiresUprnAgreement(to);

--- a/src/router/methods/metaGuards.ts
+++ b/src/router/methods/metaGuards.ts
@@ -21,25 +21,6 @@ export async function requiresAuthGuard(to: RouteLocationNormalized, from: Route
   return false;
 }
 
-export async function requiresAdmin(to: RouteLocationNormalized, from: RouteLocationNormalized, router: Router): Promise<boolean> {
-  if (to.matched.some(record => record.meta.requiresAdmin)) {
-    const userStore = useUserStore();
-    const currentUser = computed(() => userStore.currentUser);
-    const isLoggedIn = computed(() => userStore.isLoggedIn);
-    const hasPermission: boolean = currentUser.value?.roles.includes(UserRole.ADMIN)!!;
-    if (!isLoggedIn.value) {
-      await directToLogin(router);
-      return true;
-    } else if (!hasPermission) {
-      await router.push({ name: "AccessDenied" });
-      return true;
-    } else {
-      return false;
-    }
-  }
-  return false;
-}
-
 export async function requiresReAuth(to: RouteLocationNormalized, from: RouteLocationNormalized, router: Router): Promise<boolean> {
   if (to.matched.some(record => record.meta.requiresReAuth)) {
     await directToLogin(router);
@@ -48,39 +29,26 @@ export async function requiresReAuth(to: RouteLocationNormalized, from: RouteLoc
   return false;
 }
 
-export async function requiresCreateRole(to: RouteLocationNormalized, from: RouteLocationNormalized, router: Router): Promise<boolean> {
-  if (to.matched.some(record => record.meta.requiresCreateRole)) {
+export async function requiresRole(to: RouteLocationNormalized, from: RouteLocationNormalized, router: Router): Promise<boolean> {
+  console.log("Requires Role");
+  if (to.meta.requiresRole && to.meta.requiresRole.length > 0) {
+    console.log("Yes : ");
+    console.log(to.meta.requiresRole);
     const userStore = useUserStore();
-    const currentUser = computed(() => userStore.currentUser);
     const isLoggedIn = computed(() => userStore.isLoggedIn);
-    const hasPermission: boolean = currentUser.value?.roles.includes(UserRole.CREATOR)!!;
     if (!isLoggedIn.value) {
       await directToLogin(router);
       return true;
-    } else if (!hasPermission) {
-      await router.push({ name: "AccessDenied", params: { requiredAccess: "create", accessType: "role" } });
-      return true;
-    } else {
-      return false;
     }
-  }
-  return false;
-}
 
-export async function requiresEditRole(to: RouteLocationNormalized, from: RouteLocationNormalized, router: Router): Promise<boolean> {
-  if (to.matched.some(record => record.meta.requiresEditRole)) {
-    const userStore = useUserStore();
     const currentUser = computed(() => userStore.currentUser);
-    const isLoggedIn = computed(() => userStore.isLoggedIn);
-    const hasPermission: boolean = currentUser.value?.roles.includes(UserRole.EDITOR)!!;
-    if (!isLoggedIn.value) {
-      await directToLogin(router);
-      return true;
-    } else if (!hasPermission) {
-      await router.push({ name: "AccessDenied", params: { requiredAccess: "edit", accessType: "role" } });
-      return true;
-    } else {
+    const hasPermission: boolean = to.meta.requiresRole.some(r => currentUser.value?.roles.includes(r));
+
+    if (hasPermission) {
       return false;
+    } else {
+      await router.push({ name: "AccessDenied", params: { requiredAccess: to.meta.requiresRole.toString(), accessType: "role" } });
+      return true;
     }
   }
   return false;

--- a/src/router/methods/routes.ts
+++ b/src/router/methods/routes.ts
@@ -1,4 +1,5 @@
 import { RouteRecordRaw } from "vue-router";
+import { UserRole } from "@endeavour/vue-library/enums";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -77,7 +78,7 @@ const routes: Array<RouteRecordRaw> = [
         name: "Admin",
         component: () => import("@/views/AdminToolbox.vue"),
         redirect: { name: "AdminHome" },
-        meta: { requiresAdmin: true },
+        meta: { requiresRole: [UserRole.ADMIN] },
         children: [
           {
             path: "home",
@@ -97,7 +98,7 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import("@/views/Creator.vue"),
         meta: {
           requiresAuth: true,
-          requiresCreateRole: true,
+          requiresRole: [UserRole.CREATOR, UserRole.ADMIN],
           title: "Creator"
         }
       },
@@ -107,7 +108,7 @@ const routes: Array<RouteRecordRaw> = [
         meta: {
           requiresAuth: true,
           requiresLicense: true,
-          requiresEditRole: true,
+          requiresRole: [UserRole.EDITOR, UserRole.ADMIN],
           requiresOrganisation: true
         },
         children: [
@@ -170,6 +171,7 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import("@/views/Uprn.vue"),
         redirect: { name: "SingleAddressLookup" },
         meta: {
+          requiresRole: [UserRole.UPRN, UserRole.ADMIN],
           requiresAuth: true,
           requiresUprnAgreement: true
         },


### PR DESCRIPTION
- Replaced `requiresAdmin`, `requiresCreateRole`, and `requiresEditRole` guards with a single `requiresRole` guard
- Updated route meta definitions to use `requiresRole: [UserRole.XXX]` arrays instead of boolean flags
- Simplified permission checks by iterating over required roles from route metadata
- Removed redundant individual role guards from router setup in `index.ts` and `main.ts`
- Added type definition for `requiresRole` in Vue Router's `RouteMeta` interface

This change promotes consistency, reduces duplication, and makes role-based access control more flexible and maintainable.